### PR TITLE
JENKINS-33779: introduced "strip single parent" and "flatten TAP" config options

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
 		<dependency>
 			<groupId>org.tap4j</groupId>
 			<artifactId>tap4j</artifactId>
-			<version>4.1.2</version>
+			<version>4.2.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/tap4j/plugin/TapParser.java
+++ b/src/main/java/org/tap4j/plugin/TapParser.java
@@ -213,14 +213,16 @@ public class TapParser {
         } else {
             TestSet result = new TestSet();
             final List<TestResult> resultsToProcess = originalSet.getTestResults();
+            int testIndex = 1;
             while (!resultsToProcess.isEmpty()) {
-                TestResult resultToProcess = resultsToProcess.remove(0);
-                TestSet subtests = resultToProcess.getSubtest();
+                final TestResult actualTestResult = resultsToProcess.remove(0);
+                TestSet subtests = actualTestResult.getSubtest();
                 if (subtests == null || subtests.getNumberOfTestResults() == 0) {
-                    result.addTestResult(resultToProcess);
+                    actualTestResult.setTestNumber(testIndex++);
+                    result.addTestResult(actualTestResult);
                 } else {
                     for (TestResult subtestResult : subtests.getTestResults()) {
-                        subtestResult.setDescription(resultToProcess.getDescription() + subtestResult.getDescription());
+                        subtestResult.setDescription(actualTestResult.getDescription() + subtestResult.getDescription());
                         resultsToProcess.add(subtestResult);
                     }
                 }

--- a/src/main/java/org/tap4j/plugin/TapPublisher.java
+++ b/src/main/java/org/tap4j/plugin/TapPublisher.java
@@ -169,21 +169,36 @@ public class TapPublisher extends Recorder implements MatrixAggregatable {
     }
 
     public Object readResolve() {
-        String testResults = this.getTestResults();
-        Boolean failIfNoResults = BooleanUtils.toBooleanDefaultIfNull(this.getFailIfNoResults(), false);
-        Boolean failedTestsMarkBuildAsFailure = BooleanUtils.toBooleanDefaultIfNull(this.getFailedTestsMarkBuildAsFailure(), false);
-        Boolean outputTapToConsole = BooleanUtils.toBooleanDefaultIfNull(this.getOutputTapToConsole(), false);
-        Boolean enableSubtests = BooleanUtils.toBooleanDefaultIfNull(this.getEnableSubtests(), true);
-        Boolean discardOldReports = BooleanUtils.toBooleanDefaultIfNull(this.getDiscardOldReports(), false);
-        Boolean todoIsFailure = BooleanUtils.toBooleanDefaultIfNull(this.getTodoIsFailure(), true);
-        Boolean includeCommentDiagnostics = BooleanUtils.toBooleanDefaultIfNull(this.getIncludeCommentDiagnostics(), true);
-        Boolean validateNumberOfTests = BooleanUtils.toBooleanDefaultIfNull(this.getValidateNumberOfTests(), false);
-        Boolean planRequired = BooleanUtils.toBooleanDefaultIfNull(this.getPlanRequired(), true);
-        Boolean verbose = BooleanUtils.toBooleanDefaultIfNull(this.getVerbose(), true);
-        Boolean showOnlyFailures = BooleanUtils.toBooleanDefaultIfNull(this.getShowOnlyFailures(), false);
-        Boolean stripSingleParents = BooleanUtils.toBooleanDefaultIfNull(this.getStripSingleParents(), false);
+        final String _testResults = this.getTestResults();
+        final Boolean _failIfNoResults = BooleanUtils.toBooleanDefaultIfNull(this.getFailIfNoResults(), false);
+        final Boolean _failedTestsMarkBuildAsFailure = BooleanUtils.toBooleanDefaultIfNull(this.getFailedTestsMarkBuildAsFailure(), false);
+        final Boolean _outputTapToConsole = BooleanUtils.toBooleanDefaultIfNull(this.getOutputTapToConsole(), false);
+        final Boolean _enableSubtests = BooleanUtils.toBooleanDefaultIfNull(this.getEnableSubtests(), true);
+        final Boolean _discardOldReports = BooleanUtils.toBooleanDefaultIfNull(this.getDiscardOldReports(), false);
+        final Boolean _todoIsFailure = BooleanUtils.toBooleanDefaultIfNull(this.getTodoIsFailure(), true);
+        final Boolean _includeCommentDiagnostics = BooleanUtils.toBooleanDefaultIfNull(this.getIncludeCommentDiagnostics(), true);
+        final Boolean _validateNumberOfTests = BooleanUtils.toBooleanDefaultIfNull(this.getValidateNumberOfTests(), false);
+        final Boolean _planRequired = BooleanUtils.toBooleanDefaultIfNull(this.getPlanRequired(), true);
+        final Boolean _verbose = BooleanUtils.toBooleanDefaultIfNull(this.getVerbose(), true);
+        final Boolean _showOnlyFailures = BooleanUtils.toBooleanDefaultIfNull(this.getShowOnlyFailures(), false);
+        final Boolean _stripSingleParents = BooleanUtils.toBooleanDefaultIfNull(this.getStripSingleParents(), false);
+        final Boolean _flattenTapResult = BooleanUtils.toBooleanDefaultIfNull(this.getFlattenTapResult(), false);
 
-        return new TapPublisher(testResults, failIfNoResults, failedTestsMarkBuildAsFailure, outputTapToConsole, enableSubtests, discardOldReports, todoIsFailure, includeCommentDiagnostics, validateNumberOfTests, planRequired, verbose, showOnlyFailures, stripSingleParents);
+        return new TapPublisher(
+                _testResults,
+                _failIfNoResults,
+                _failedTestsMarkBuildAsFailure,
+                _outputTapToConsole,
+                _enableSubtests,
+                _discardOldReports,
+                _todoIsFailure,
+                _includeCommentDiagnostics,
+                _validateNumberOfTests,
+                _planRequired,
+                _verbose,
+                _showOnlyFailures,
+                _stripSingleParents,
+                _flattenTapResult);
     }
 
     public Boolean getShowOnlyFailures() {

--- a/src/main/java/org/tap4j/plugin/TapPublisher.java
+++ b/src/main/java/org/tap4j/plugin/TapPublisher.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2010 Bruno P. Kinoshita
+ * Copyright (c) 2010-2016 Bruno P. Kinoshita
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -77,6 +77,7 @@ public class TapPublisher extends Recorder implements MatrixAggregatable {
     private final Boolean verbose;
     private final Boolean showOnlyFailures;
     private final Boolean stripSingleParents;
+    private final Boolean flattenTapResult;
 
     @Deprecated
     public TapPublisher(String testResults,
@@ -115,7 +116,7 @@ public class TapPublisher extends Recorder implements MatrixAggregatable {
                 Boolean.FALSE, Boolean.FALSE);
     }
 
-    @DataBoundConstructor
+    @Deprecated
     public TapPublisher(String testResults,
             Boolean failIfNoResults,
             Boolean failedTestsMarkBuildAsFailure,
@@ -129,6 +130,27 @@ public class TapPublisher extends Recorder implements MatrixAggregatable {
             Boolean verbose,
             Boolean showOnlyFailures,
             Boolean stripSingleParents) {
+        this(testResults, failIfNoResults, failedTestsMarkBuildAsFailure,
+                outputTapToConsole, enableSubtests, discardOldReports, todoIsFailure,
+                includeCommentDiagnostics, validateNumberOfTests, planRequired, verbose,
+                Boolean.FALSE, Boolean.FALSE, Boolean.FALSE);
+    }
+
+    @DataBoundConstructor
+    public TapPublisher(String testResults,
+            Boolean failIfNoResults,
+            Boolean failedTestsMarkBuildAsFailure,
+            Boolean outputTapToConsole,
+            Boolean enableSubtests,
+            Boolean discardOldReports,
+            Boolean todoIsFailure,
+            Boolean includeCommentDiagnostics,
+            Boolean validateNumberOfTests,
+            Boolean planRequired,
+            Boolean verbose,
+            Boolean showOnlyFailures,
+            Boolean stripSingleParents,
+            Boolean flattenTapResult) {
 
         this.testResults = testResults;
         this.failIfNoResults = BooleanUtils.toBooleanDefaultIfNull(failIfNoResults, false);
@@ -143,6 +165,7 @@ public class TapPublisher extends Recorder implements MatrixAggregatable {
         this.verbose = BooleanUtils.toBooleanDefaultIfNull(verbose, true);
         this.showOnlyFailures = BooleanUtils.toBooleanDefaultIfNull(showOnlyFailures, false);
         this.stripSingleParents = BooleanUtils.toBooleanDefaultIfNull(stripSingleParents, false);
+        this.flattenTapResult = BooleanUtils.toBooleanDefaultIfNull(flattenTapResult, false);
     }
 
     public Object readResolve() {
@@ -234,6 +257,10 @@ public class TapPublisher extends Recorder implements MatrixAggregatable {
 
     public Boolean getVerbose() {
         return verbose;
+    }
+
+    public Boolean getFlattenTapResult() {
+        return flattenTapResult;
     }
 
     /**
@@ -385,7 +412,9 @@ public class TapPublisher extends Recorder implements MatrixAggregatable {
         TapResult tr = null;
         try {
             results = tapDir.list("**/*.*");
-            final TapParser parser = new TapParser(getOutputTapToConsole(), getEnableSubtests(), getTodoIsFailure(), getIncludeCommentDiagnostics(), getValidateNumberOfTests(), getPlanRequired(), getVerbose(), getStripSingleParents(), logger);
+            final TapParser parser = new TapParser(getOutputTapToConsole(), getEnableSubtests(), getTodoIsFailure(), getIncludeCommentDiagnostics(),
+                    getValidateNumberOfTests(), getPlanRequired(), getVerbose(), getStripSingleParents(), getFlattenTapResult(), logger);
+
             final TapResult result = parser.parse(results, owner);
             result.setOwner(owner);
             return result;
@@ -537,5 +566,4 @@ public class TapPublisher extends Recorder implements MatrixAggregatable {
         }
 
     }
-
 }

--- a/src/main/resources/org/tap4j/plugin/TapPublisher/config.jelly
+++ b/src/main/resources/org/tap4j/plugin/TapPublisher/config.jelly
@@ -40,5 +40,8 @@
       <f:entry title="Strip single parents">
           <f:checkbox name="TapPublisher.stripSingleParents" value="${instance.stripSingleParents}" checked="${instance.stripSingleParents}" default="false" />
       </f:entry>
+      <f:entry title="Flatten TAP result">
+          <f:checkbox name="TapPublisher.flattenTapResult" value="${instance.flattenTapResult}" checked="${instance.flattenTapResult}" default="false" />
+      </f:entry>
   </f:advanced>
 </j:jelly>

--- a/src/main/resources/org/tap4j/plugin/TapPublisher/config.jelly
+++ b/src/main/resources/org/tap4j/plugin/TapPublisher/config.jelly
@@ -37,5 +37,8 @@
       <f:entry title="Show only failures">
           <f:checkbox name="TapPublisher.showOnlyFailures" value="${instance.showOnlyFailures}" checked="${instance.showOnlyFailures}" default="false" />
       </f:entry>
+      <f:entry title="Strip single parents">
+          <f:checkbox name="TapPublisher.stripSingleParents" value="${instance.stripSingleParents}" checked="${instance.stripSingleParents}" default="false" />
+      </f:entry>
   </f:advanced>
 </j:jelly>

--- a/src/main/resources/org/tap4j/plugin/TapResult/index.jelly
+++ b/src/main/resources/org/tap4j/plugin/TapResult/index.jelly
@@ -33,10 +33,10 @@
 					<j:forEach var="map" items="${it.testSets}">
 					   <j:choose>
 					     <j:when test="${map.getTestSet().getPlan().isSkip()}">
-						   <p>File: <span class="underline"><a href='${rootURL}/${it.owner.project.url}ws/${map.fileName}/*view*/'>${map.fileName}</a></span> (Skipped)</p>
+						   <p>File: <span class="underline"><a href='${rootURL}/${it.owner.url}artifact/${map.fileName}/*view*/'>${map.fileName}</a></span> (Skipped)</p>
 						 </j:when>
 						 <j:otherwise>
-					       <p>File: <span class="underline"><a href='${rootURL}/${it.owner.project.url}ws/${map.fileName}/*view*/'>${map.fileName}</a></span></p>
+					       <p>File: <span class="underline"><a href='${rootURL}/${it.owner.url}artifact/${map.fileName}/*view*/'>${map.fileName}</a></span></p>
 						 </j:otherwise>
 					   </j:choose>
 						 <table class="tap" width="100%">
@@ -71,7 +71,7 @@
                         </tr>
                         <j:forEach var="map" items="${it.parseErrorTestSets}">
                         <tr>
-                            <td><a href='${rootURL}/${it.owner.project.url}ws/${map.fileName}/*view*/'>${map.fileName}</a></td>
+                            <td><a href='${rootURL}/${it.owner.url}artifact/${map.fileName}/*view*/'>${map.fileName}</a></td>
                             <td>${map.cause}</td>
                         </tr>
                         </j:forEach>

--- a/src/test/java/org/tap4j/plugin/flattentapfeature/TestFlattenTapResult.java
+++ b/src/test/java/org/tap4j/plugin/flattentapfeature/TestFlattenTapResult.java
@@ -1,0 +1,148 @@
+package org.tap4j.plugin.flattentapfeature;
+
+import hudson.Launcher;
+import hudson.model.BuildListener;
+import hudson.model.FreeStyleBuild;
+import hudson.model.AbstractBuild;
+import hudson.model.FreeStyleProject;
+import java.io.ByteArrayOutputStream;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.ExecutionException;
+
+import org.jvnet.hudson.test.HudsonTestCase;
+import org.jvnet.hudson.test.TestBuilder;
+import org.tap4j.model.TestResult;
+import org.tap4j.model.TestSet;
+import org.tap4j.plugin.TapPublisher;
+import org.tap4j.plugin.TapResult;
+import org.tap4j.plugin.TapTestResultAction;
+
+/**
+ * Tests for flatten TAP result configuration option.
+ *
+ * @author Jakub Podlesak
+ */
+public class TestFlattenTapResult extends HudsonTestCase {
+
+    public void testMixedLevels() throws IOException, InterruptedException, ExecutionException {
+
+        final String tap = "1..2\n" +
+                "ok 1 1\n" +
+                "  1..3\n" +
+                "  ok 1 1.1\n" +
+                "  ok 2 1.2\n" +
+                "  ok 3 1.3\n" +
+                "ok 2 2\n";
+
+        _test(tap, 4, null, false);
+    }
+
+    public void testStripFirstLevel() throws IOException, InterruptedException, ExecutionException {
+
+        final String tap = "1..2\n" +
+                "ok 1 1\n" +
+                "  1..2\n" +
+                "  ok 1 .1\n" +
+                "  ok 2 .2\n" +
+                "ok 2 2\n" +
+                "  1..3\n" +
+                "  ok 1 .1\n" +
+                "  ok 2 .2\n" +
+                "  ok 3 .3\n";
+
+        _test(tap, 5, new String[] {
+            "1.1", "1.2",
+            "2.1", "2.2", "2.3"}, false);
+    }
+
+    public void testStripSecondLevel() throws IOException, InterruptedException, ExecutionException {
+
+        final String tap =
+                "1..1\n" +
+                "ok 1 1\n" +
+                "  1..2\n" +
+                "  ok 1 .1\n" +
+                "    1..3\n" +
+                "    ok 1 .1\n" +
+                "    ok 2 .2\n" +
+                "    ok 3 .3\n" +
+                "    ok 4 .4\n" +
+                "  ok 2 .2\n" +
+                "    1..2\n" +
+                "    ok 1 .1\n" +
+                "    ok 2 .2\n" +
+                "    ok 3 .3\n";
+
+        _test(tap, 7,
+                new String[] {
+                    "1.1.1", "1.1.2", "1.1.3", "1.1.4",
+                    "1.2.1", "1.2.2", "1.2.3"}, false);
+    }
+
+    public void testARealTapOuptut() throws Exception {
+        final String tap = _is2String(TestFlattenTapResult.class.getResourceAsStream("/org/tap4j/plugin/tap-master-files/subtest-sample.tap"));
+        _test(tap, 48, null, true);
+    }
+
+    private String _is2String(InputStream is) throws IOException {
+        ByteArrayOutputStream result = new ByteArrayOutputStream();
+        byte[] buffer = new byte[1024];
+        int length;
+        while ((length = is.read(buffer)) != -1) {
+            result.write(buffer, 0, length);
+        }
+        return result.toString("UTF-8");
+    }
+
+    private void _test(final String tap, int expectedTotal, String[] expectedDescriptions, boolean printDescriptions) throws IOException, InterruptedException, ExecutionException {
+        FreeStyleProject project = this.hudson.createProject(FreeStyleProject.class, "flatten-the-file");
+
+        project.getBuildersList().add(new TestBuilder() {
+            @Override
+            public boolean perform(AbstractBuild<?, ?> build, Launcher arg1,
+                    BuildListener arg2) throws InterruptedException, IOException {
+                build.getWorkspace().child("result.tap").write(tap,"UTF-8");
+                return true;
+            }
+        });
+
+        TapPublisher publisher = new TapPublisher(
+                "result.tap", // test results
+                true,  // failIfNoResults
+                true,  // failedTestsMarkBuildAsFailure
+                false, // outputTapToConsole
+                true,  // enableSubtests
+                true,  // discardOldReports
+                true,  // todoIsFailure
+                true,  // includeCommentDiagnostics
+                true,  // validateNumberOfTests
+                true,  // planRequired
+                false, // verbose
+                true,  // showOnlyFailures
+                false, // stripSingleParents
+                true); // flattenTapResult
+
+        project.getPublishersList().add(publisher);
+        project.save();
+        FreeStyleBuild build = (FreeStyleBuild) project.scheduleBuild2(0).get();
+
+        TapTestResultAction action = build.getAction(TapTestResultAction.class);
+        TapResult testResult = action.getTapResult();
+
+        assertEquals(expectedTotal, testResult.getPassed());
+
+        final TestSet testSet = testResult.getTestSets().get(0).getTestSet();
+        int testIndex = 0;
+        for (TestResult result : testSet.getTestResults()) {
+            final String description = result.getDescription();
+            if (expectedDescriptions != null) {
+                assertEquals(description, expectedDescriptions[testIndex++]);
+            }
+            if (printDescriptions) {
+                System.out.println(description);
+            }
+        }
+    }
+}

--- a/src/test/java/org/tap4j/plugin/flattentapfeature/TestFlattenTapResult.java
+++ b/src/test/java/org/tap4j/plugin/flattentapfeature/TestFlattenTapResult.java
@@ -136,13 +136,21 @@ public class TestFlattenTapResult extends HudsonTestCase {
         final TestSet testSet = testResult.getTestSets().get(0).getTestSet();
         int testIndex = 0;
         for (TestResult result : testSet.getTestResults()) {
+
             final String description = result.getDescription();
+            int expectedTestNumber = testIndex +1;
+
+            assertEquals(result.getTestNumber().intValue(), expectedTestNumber);
+
             if (expectedDescriptions != null) {
-                assertEquals(description, expectedDescriptions[testIndex++]);
+                assertEquals(description, expectedDescriptions[testIndex]);
             }
+
             if (printDescriptions) {
                 System.out.println(description);
             }
+
+            testIndex ++;
         }
     }
 }

--- a/src/test/java/org/tap4j/plugin/flattentapfeature/package-info.java
+++ b/src/test/java/org/tap4j/plugin/flattentapfeature/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Tests flatten TAP result feature feature.
+ */
+package org.tap4j.plugin.flattentapfeature;

--- a/src/test/java/org/tap4j/plugin/stripsingleparent/TestStripSingleParent.java
+++ b/src/test/java/org/tap4j/plugin/stripsingleparent/TestStripSingleParent.java
@@ -1,0 +1,101 @@
+package org.tap4j.plugin.stripsingleparent;
+
+import hudson.Launcher;
+import hudson.model.BuildListener;
+import hudson.model.FreeStyleBuild;
+import hudson.model.AbstractBuild;
+import hudson.model.FreeStyleProject;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+import org.jvnet.hudson.test.HudsonTestCase;
+import org.jvnet.hudson.test.TestBuilder;
+import org.tap4j.plugin.TapPublisher;
+import org.tap4j.plugin.TapResult;
+import org.tap4j.plugin.TapTestResultAction;
+
+/**
+ * At least basic tests for strip single parent configuration option.
+ *
+ * @author Jakub Podlesak
+ */
+public class TestStripSingleParent extends HudsonTestCase {
+
+    public void testNoEffect() throws IOException, InterruptedException, ExecutionException {
+
+        final String tap = "1..2\n" +
+                "ok 1 - 1\n" +
+                "  1..3\n" +
+                "  ok 1 1.1\n" +
+                "  ok 2 1.2\n" +
+                "  ok 3 1.3\n" +
+                "ok 2 - 1\n";
+
+        _test(tap, 2);
+    }
+
+    public void testStripFirstLevel() throws IOException, InterruptedException, ExecutionException {
+
+        final String tap = "1..1\n" +
+                "ok 1 - 1\n" +
+                "  1..3\n" +
+                "  ok 1 1.1\n" +
+                "  ok 2 1.2\n" +
+                "  ok 3 1.3\n";
+
+        _test(tap, 3);
+    }
+
+    public void testStripSecondLevel() throws IOException, InterruptedException, ExecutionException {
+
+        final String tap =
+                "1..1\n" +
+                "ok 1 - 1\n" +
+                "  1..1\n" +
+                "  ok 1.1 - 1\n" +
+                "    1..3\n" +
+                "    ok 1 1.1.1\n" +
+                "    ok 2 1.1.2\n" +
+                "    ok 3 1.1.3\n";
+
+        _test(tap, 3);
+    }
+
+    private void _test(final String tap, int expectedTotal) throws IOException, InterruptedException, ExecutionException {
+        FreeStyleProject project = this.hudson.createProject(FreeStyleProject.class, "strip-single-parents");
+
+        project.getBuildersList().add(new TestBuilder() {
+            @Override
+            public boolean perform(AbstractBuild<?, ?> build, Launcher arg1,
+                    BuildListener arg2) throws InterruptedException, IOException {
+                build.getWorkspace().child("result.tap").write(tap,"UTF-8");
+                return true;
+            }
+        });
+
+        TapPublisher publisher = new TapPublisher(
+                "result.tap", // test results
+                true,  // failIfNoResults
+                true,  // failedTestsMarkBuildAsFailure
+                false, // outputTapToConsole
+                true,  // enableSubtests
+                true,  // discardOldReports
+                true,  // todoIsFailure
+                true,  // includeCommentDiagnostics
+                true,  // validateNumberOfTests
+                true,  // planRequired
+                false, // verbose
+                true,  // showOnlyFailures
+                true); // stripSingleParents
+
+        project.getPublishersList().add(publisher);
+        project.save();
+        FreeStyleBuild build = (FreeStyleBuild) project.scheduleBuild2(0).get();
+
+        TapTestResultAction action = build.getAction(TapTestResultAction.class);
+        TapResult testResult = action.getTapResult();
+
+        assertEquals(expectedTotal, testResult.getPassed());
+    }
+}

--- a/src/test/java/org/tap4j/plugin/stripsingleparent/TestStripSingleParent.java
+++ b/src/test/java/org/tap4j/plugin/stripsingleparent/TestStripSingleParent.java
@@ -87,7 +87,8 @@ public class TestStripSingleParent extends HudsonTestCase {
                 true,  // planRequired
                 false, // verbose
                 true,  // showOnlyFailures
-                true); // stripSingleParents
+                true,  // stripSingleParents
+                false); // flattenTapResult
 
         project.getPublishersList().add(publisher);
         project.save();

--- a/src/test/java/org/tap4j/plugin/stripsingleparent/package-info.java
+++ b/src/test/java/org/tap4j/plugin/stripsingleparent/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Tests stripping single parent feature.
+ */
+package org.tap4j.plugin.stripsingleparent;

--- a/src/test/resources/org/tap4j/plugin/tap-master-files/subtest-sample.tap
+++ b/src/test/resources/org/tap4j/plugin/tap-master-files/subtest-sample.tap
@@ -1,0 +1,144 @@
+TAP version 13
+    # Subtest: test/tap/access.js
+        # Subtest: setup
+        ok 1 - /workdir/npm-module/test/tap/access made successfully
+        ok 2 - registry mocked successfully
+        ok 3 - wrote package.json
+        1..3
+    ok 1 - setup # time=68.43ms
+
+        # Subtest: npm access public on current package
+        ok 1 - npm access
+        ok 2 - exited OK
+        ok 3 - no error output
+        1..3
+    ok 2 - npm access public on current package # time=543.472ms
+
+        # Subtest: npm access public when no package passed and no package.json
+        ok 1 - npm access
+        ok 2 - should match pattern provided
+        1..2
+    ok 3 - npm access public when no package passed and no package.json # time=457.195ms
+
+        # Subtest: npm access public when no package passed and invalid package.json
+        ok 1 - npm access
+        ok 2 - should match pattern provided
+        1..2
+    ok 4 - npm access public when no package passed and invalid package.json # time=458.715ms
+
+        # Subtest: npm access restricted on current package
+        ok 1 - npm access
+        ok 2 - exited OK
+        ok 3 - no error output
+        1..3
+    ok 5 - npm access restricted on current package # time=548.049ms
+
+        # Subtest: npm access on named package
+        ok 1 - npm access
+        ok 2 - exited OK
+        ok 3 - no error output
+        1..3
+    ok 6 - npm access on named package # time=519.159ms
+
+        # Subtest: npm change access on unscoped package
+        ok 1 - exited with Error
+        ok 2 - should match pattern provided
+        1..2
+    ok 7 - npm change access on unscoped package # time=461.458ms
+
+        # Subtest: npm access grant read-only
+        ok 1 - npm access grant
+        ok 2 - exited with Error
+        1..2
+    ok 8 - npm access grant read-only # time=517.935ms
+
+        # Subtest: npm access grant read-write
+        ok 1 - npm access grant
+        ok 2 - exited with Error
+        1..2
+    ok 9 - npm access grant read-write # time=525.574ms
+
+        # Subtest: npm access grant others
+        ok 1 - exited with Error
+        ok 2 - should match pattern provided
+        ok 3 - should match pattern provided
+        1..3
+    ok 10 - npm access grant others # time=473.668ms
+
+        # Subtest: npm access revoke
+        ok 1 - npm access grant
+        ok 2 - exited with Error
+        1..2
+    ok 11 - npm access revoke # time=529.943ms
+
+        # Subtest: npm access ls-packages with no team
+        ok 1 - npm access ls-packages
+        ok 2 - should be equivalent
+        1..2
+    ok 12 - npm access ls-packages with no team # time=512.118ms
+
+        # Subtest: npm access ls-packages on team
+        ok 1 - npm access ls-packages
+        ok 2 - should be equivalent
+        1..2
+    ok 13 - npm access ls-packages on team # time=530.445ms
+
+        # Subtest: npm access ls-packages on org
+        ok 1 - npm access ls-packages
+        ok 2 - should be equivalent
+        1..2
+    ok 14 - npm access ls-packages on org # time=538.885ms
+
+        # Subtest: npm access ls-packages on user
+        ok 1 - npm access ls-packages
+        ok 2 - should be equivalent
+        1..2
+    ok 15 - npm access ls-packages on user # time=509.704ms
+
+        # Subtest: npm access ls-packages with no package specified or package.json
+        ok 1 - npm access ls-packages
+        ok 2 - should be equivalent
+        1..2
+    ok 16 - npm access ls-packages with no package specified or package.json # time=506.721ms
+
+        # Subtest: npm access ls-collaborators on current
+        ok 1 - npm access ls-collaborators
+        ok 2 - should be equivalent
+        1..2
+    ok 17 - npm access ls-collaborators on current # time=516.851ms
+
+        # Subtest: npm access ls-collaborators on package
+        ok 1 - npm access ls-collaborators
+        ok 2 - should be equivalent
+        1..2
+    ok 18 - npm access ls-collaborators on package # time=508.724ms
+
+        # Subtest: npm access ls-collaborators on current w/user filter
+        ok 1 - npm access ls-collaborators
+        ok 2 - should be equivalent
+        1..2
+    ok 19 - npm access ls-collaborators on current w/user filter # time=501.361ms
+
+        # Subtest: npm access edit
+        ok 1 - exited with Error
+        ok 2 - should match pattern provided
+        1..2
+    ok 20 - npm access edit # time=444.677ms
+
+        # Subtest: npm access blerg
+        ok 1 - exited with Error
+        ok 2 - should match pattern provided
+        1..2
+    ok 21 - npm access blerg # time=443.858ms
+
+        # Subtest: cleanup
+        ok 1 - cleaned up
+        1..1
+    ok 22 - cleanup # time=3.574ms
+
+    1..22
+    # time=10166.406ms
+ok 1 - test/tap/access.js # time=10398.064ms
+
+1..1
+# time=10431.957ms


### PR DESCRIPTION
The new option should be handy if you have to process a TAP file like the following one:
```
1..1
not ok 1
  1..1024
  ok 1 test 1
  ok 2 test 2
  not ok 3 test 3
  ok 4 test 4
  ...
```
The new feature is disabled by default, so that it does not break existing behaviour.
I have also bumped the TAP parser version to 4.2.0.