### PR TITLE
JENKINS-22016: Enable test status rollup displays on the Dashboard

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 	<groupId>org.tap4j</groupId>
 	<artifactId>tap</artifactId>
 	<name>Jenkins TAP Plugin</name>
-	<version>1.25-SNAPSHOT</version>
+	<version>1.26-EVANDY</version>
 	<packaging>hpi</packaging>
 
 	<licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 	<groupId>org.tap4j</groupId>
 	<artifactId>tap</artifactId>
 	<name>Jenkins TAP Plugin</name>
-	<version>1.26.1-EVANDY</version>
+	<version>1.25-SNAPSHOT</version>
 	<packaging>hpi</packaging>
 
 	<licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 	<groupId>org.tap4j</groupId>
 	<artifactId>tap</artifactId>
 	<name>Jenkins TAP Plugin</name>
-	<version>1.26-EVANDY</version>
+	<version>1.26.1-EVANDY</version>
 	<packaging>hpi</packaging>
 
 	<licenses>

--- a/src/main/java/org/tap4j/plugin/AbstractTapProjectAction.java
+++ b/src/main/java/org/tap4j/plugin/AbstractTapProjectAction.java
@@ -23,7 +23,9 @@
  */
 package org.tap4j.plugin;
 
+import hudson.model.AbstractProject;
 import hudson.model.Action;
+import hudson.tasks.test.TestResultProjectAction;
 
 /**
  * Base class for TAP Project action.
@@ -31,7 +33,11 @@ import hudson.model.Action;
  * @author Bruno P. Kinoshita - http://www.kinoshita.eti.br
  * @since 1.0
  */
-public class AbstractTapProjectAction implements Action {
+public class AbstractTapProjectAction extends TestResultProjectAction implements Action {
+
+    public AbstractTapProjectAction(AbstractProject<?, ?> project) {
+        super(project); 
+    }
 
     public static final String URL_NAME = "tapResults";
     public static final String ICON_NAME = "/plugin/tap/icons/tap-24.png";

--- a/src/main/java/org/tap4j/plugin/TapProjectAction.java
+++ b/src/main/java/org/tap4j/plugin/TapProjectAction.java
@@ -59,6 +59,7 @@ public class TapProjectAction extends AbstractTapProjectAction {
     private transient Map<String, Integer> requestMap = new HashMap<String, Integer>();
 
     public TapProjectAction(AbstractProject<?, ?> project) {
+        super(project);
         this.project = project;
     }
 

--- a/src/main/java/org/tap4j/plugin/TapProjectAction.java
+++ b/src/main/java/org/tap4j/plugin/TapProjectAction.java
@@ -26,6 +26,8 @@ package org.tap4j.plugin;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.Run;
+import hudson.model.Job;
+import hudson.matrix.MatrixProject;
 import hudson.util.ChartUtil;
 import hudson.util.DataSetBuilder;
 import hudson.util.RunList;
@@ -50,6 +52,24 @@ import org.tap4j.plugin.util.GraphHelper;
 public class TapProjectAction extends AbstractTapProjectAction {
 
     private AbstractProject<?, ?> project;
+    
+    protected class Result {
+        public int numPassed;
+        public int numFailed;
+        public int numSkipped;
+        
+        public Result() {
+            numPassed = 0;
+            numFailed = 0;
+            numSkipped = 0;
+        }
+        
+        public void add(Result r) {
+          numPassed += r.numPassed;
+          numFailed += r.numFailed;
+          numSkipped += r.numSkipped;
+        }
+    }
 
     /**
      * Used to figure out if we need to regenerate the graphs or not. Only used
@@ -150,14 +170,36 @@ public class TapProjectAction extends AbstractTapProjectAction {
      */
     public boolean isGraphActive() {
         AbstractBuild<?, ?> build = getProject().getLastBuild();
+        AbstractProject<?,?> p = getProject();
         // in order to have a graph, we must have at least two points.
         int numPoints = 0;
         while (numPoints < 2) {
             if (build == null) {
                 return false;
             }
-            if (build.getAction(getBuildActionClass()) != null) {
-                numPoints++;
+            if( p instanceof MatrixProject )
+            {
+                MatrixProject mp = (MatrixProject) p;
+ 
+                for (Job j : mp.getAllJobs()) {
+                   if (j != mp) { //getAllJobs includes the parent job too, so skip that
+                       Run<?,?> sub = j.getBuild(build.getId());
+                       if(sub != null) {
+                           // Not all builds are on all sub-projects
+                           if (sub.getAction(getBuildActionClass()) != null) {
+                               //data for at least 1 sub-job on this build
+                               numPoints++;
+                               break; // go look at the next build now
+                           }
+                       }
+                   }
+                }
+            }
+            else
+            {
+                if (build.getAction(getBuildActionClass()) != null) {
+                    numPoints++;
+                }
             }
             build = build.getPreviousBuild();
         }
@@ -206,23 +248,54 @@ public class TapProjectAction extends AbstractTapProjectAction {
 
     protected void populateDataSetBuilder(DataSetBuilder<String, ChartUtil.NumberOnlyBuildLabel> dataset ) {
 
+        AbstractProject<?, ?> p = getProject();
+        
         for (Run<?, ?> build = getProject().getLastBuild(); build != null; build = build.getPreviousBuild()) {
             ChartUtil.NumberOnlyBuildLabel label = new ChartUtil.NumberOnlyBuildLabel((Run<?, ?>) build);
-            TapBuildAction action = build.getAction(getBuildActionClass());
-            if (action != null) {
-                TapResult report = action.getResult();
-                report.tally();
 
-                dataset.add(report.getPassed(), "Passed",
-                        label);
-                dataset.add(report.getFailed(), "Failed",
-                        label);
-                dataset.add(report.getSkipped(),
-                        "Skipped", label);
+            Result r = new Result();
+            
+            if( p instanceof MatrixProject )
+            {
+                MatrixProject mp = (MatrixProject) p;
+ 
+                for (Job j : mp.getAllJobs()) {
+                   if (j != mp) { //getAllJobs includes the parent job too, so skip that
+                       Run<?,?> sub = j.getBuild(build.getId());
+                       if(sub != null) {
+                           // Not all builds are on all sub-projects
+                           r.add(summarizeBuild(sub));
+                       }
+                   }
+                }
             }
+            else
+            {
+                r = summarizeBuild(build);
+            }
+            
+            dataset.add(r.numPassed, "Passed", label);
+            dataset.add(r.numFailed, "Failed", label);
+            dataset.add(r.numSkipped, "Skipped", label);
         }
     }
 
+    protected Result summarizeBuild(Run<?,?> b)
+    {
+        Result r = new Result();
+        
+        TapBuildAction action = b.getAction(getBuildActionClass());
+        if (action != null) {
+            TapResult report = action.getResult();
+            report.tally();
+
+            r.numPassed = report.getPassed();
+            r.numFailed = report.getFailed();
+            r.numSkipped = report.getSkipped();
+        }
+
+        return r;
+    }
     /**
      * Getter for property 'graphWidth'.
      * 


### PR DESCRIPTION
Addresses the rollup on the dashboard view by inheriting the TapProjectAction from the generic TestResultProjectAction class.   Just replacing the class resulted in broken test charts on the inner job pages, but this keeps existing functionality, and fixes the dashboard view.

This does NOT address getting the aggregated test chart to display on the matrix job's main page... still need to look into that piece, but this change appears stable, useful, and worth pulling, even without the last part.
![screen shot 2016-05-03 at 6 39 05 pm](https://cloud.githubusercontent.com/assets/12788951/15001610/b6233de6-115e-11e6-9e94-bc029ada463c.png)
![screen shot 2016-05-03 at 6 42 05 pm](https://cloud.githubusercontent.com/assets/12788951/15001615/c32e8c66-115e-11e6-94d6-866b1d6a2683.png)

