### PR TITLE
convert durationString to match duration_ms

### DIFF
--- a/src/main/resources/org/tap4j/plugin/TapTestResultAction/index.jelly
+++ b/src/main/resources/org/tap4j/plugin/TapTestResultAction/index.jelly
@@ -35,7 +35,7 @@ THE SOFTWARE.
 
       <div style="text-align:right;">
         <a href="history">
-          ${%took(it.durationString)}
+          ${%took(it.durationString / 1000)}
         </a>
       </div>
 


### PR DESCRIPTION
when https://github.com/jenkinsci/tap-plugin/pull/6 was landed the overall test time was never updated. This PR fixes that issue by also dividing the overall duration by 1000.