### PR TITLE
[JENKINS-48925] continuation - whitelisted `org.tap4j.model.Text`.

### DIFF
--- a/src/main/resources/META-INF/hudson.remoting.ClassFilter
+++ b/src/main/resources/META-INF/hudson.remoting.ClassFilter
@@ -11,3 +11,4 @@ org.tap4j.model.TapElement
 org.tap4j.model.TapResult
 org.tap4j.model.TestResult
 org.tap4j.model.TestSet
+org.tap4j.model.Text


### PR DESCRIPTION
# What
The list of whitelisted classes turned out to be incomplete. The latest TAP Plugin 2.2 with Jenkins 2.105 throws the error below when publishing results, the fix is to add missing class to class filter.

@kinow, @oleg-nenashev: any thoughts?

Thanks.

# Exception
```
        ... 50 more                                                                                                                                             
Caused by: java.lang.RuntimeException: Failed to serialize org.tap4j.model.TestSet#tapLines for class org.tap4j.model.TestSet                                   
        at hudson.util.RobustReflectionConverter$2.writeField(RobustReflectionConverter.java:256)                                                               
        at hudson.util.RobustReflectionConverter$2.visit(RobustReflectionConverter.java:224)                                                                    
        at com.thoughtworks.xstream.converters.reflection.PureJavaReflectionProvider.visitSerializableFields(PureJavaReflectionProvider.java:138)               
        at hudson.util.RobustReflectionConverter.doMarshal(RobustReflectionConverter.java:209)                                                                  
        at hudson.util.RobustReflectionConverter.marshal(RobustReflectionConverter.java:150)                                                                    
        at com.thoughtworks.xstream.core.AbstractReferenceMarshaller.convert(AbstractReferenceMarshaller.java:69)                                               
        at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:58)                                                                  
        at com.thoughtworks.xstream.core.AbstractReferenceMarshaller$1.convertAnother(AbstractReferenceMarshaller.java:84)                                      
        at hudson.util.RobustReflectionConverter.marshallField(RobustReflectionConverter.java:265)                                                              
        at hudson.util.RobustReflectionConverter$2.writeField(RobustReflectionConverter.java:252)                                                               
        ... 65 more                                                                                                                                             
Caused by: java.lang.UnsupportedOperationException: Refusing to marshal org.tap4j.model.Text for security reasons; see https://jenkins.io/redirect/class-filter/
        at hudson.util.XStream2$BlacklistedTypesConverter.marshal(XStream2.java:543)                                                                            
        at com.thoughtworks.xstream.core.AbstractReferenceMarshaller.convert(AbstractReferenceMarshaller.java:69)                                               
        at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:58)                                                                  
        at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:43)                                                                  
        at com.thoughtworks.xstream.core.AbstractReferenceMarshaller$1.convertAnother(AbstractReferenceMarshaller.java:88)                                      
        at com.thoughtworks.xstream.converters.collections.AbstractCollectionConverter.writeItem(AbstractCollectionConverter.java:64)                           
        at com.thoughtworks.xstream.converters.collections.CollectionConverter.marshal(CollectionConverter.java:74)                                             
        at com.thoughtworks.xstream.core.AbstractReferenceMarshaller.convert(AbstractReferenceMarshaller.java:69)                                               
        at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:58)                                                                  
        at com.thoughtworks.xstream.core.AbstractReferenceMarshaller$1.convertAnother(AbstractReferenceMarshaller.java:84)                                      
        at hudson.util.RobustReflectionConverter.marshallField(RobustReflectionConverter.java:265)                                                              
        at hudson.util.RobustReflectionConverter$2.writeField(RobustReflectionConverter.java:252)                                                               
        ... 74 more                                                                                                                                             
```