### PR TITLE
tap4j dependency upgraded to 4.4.2 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,9 +51,9 @@
 
 	<properties>
 		<jenkins.version>1.642.3</jenkins.version>
-		<java.level>7</java.level>
+		<java.level>8</java.level>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<tap4j.version>4.2.1</tap4j.version>
+		<tap4j.version>4.4.2</tap4j.version>
 		<junit.plugin.version>1.6</junit.plugin.version>
 		<!-- TODO: remove once FindBugs issues are fixed -->
 		<findbugs.failOnError>false</findbugs.failOnError>

--- a/src/test/java/org/tap4j/plugin/flattentapfeature/TestFlattenTapResult.java
+++ b/src/test/java/org/tap4j/plugin/flattentapfeature/TestFlattenTapResult.java
@@ -38,11 +38,11 @@ public class TestFlattenTapResult {
     public void testMixedLevels() throws IOException, InterruptedException, ExecutionException {
 
         final String tap = "1..2\n" +
-                "ok 1 1\n" +
                 "  1..3\n" +
                 "  ok 1 1.1\n" +
                 "  ok 2 1.2\n" +
                 "  ok 3 1.3\n" +
+                "ok 1 1\n" +
                 "ok 2 2\n";
 
         _test(tap, 4, null, false);
@@ -52,15 +52,15 @@ public class TestFlattenTapResult {
     public void testStripFirstLevel() throws IOException, InterruptedException, ExecutionException {
 
         final String tap = "1..2\n" +
-                "ok 1 1\n" +
                 "  1..2\n" +
                 "  ok 1 .1\n" +
                 "  ok 2 .2\n" +
-                "ok 2 2\n" +
+                "ok 1 1\n" +
                 "  1..3\n" +
                 "  ok 1 .1\n" +
                 "  ok 2 .2\n" +
-                "  ok 3 .3\n";
+                "  ok 3 .3\n" +
+                "ok 2 2\n";
 
         _test(tap, 5, new String[] {
             "1.1", "1.2",
@@ -72,19 +72,19 @@ public class TestFlattenTapResult {
 
         final String tap =
                 "1..1\n" +
-                "ok 1 1\n" +
                 "  1..2\n" +
-                "  ok 1 .1\n" +
                 "    1..4\n" +
                 "    ok 1 .1\n" +
                 "    ok 2 .2\n" +
                 "    ok 3 .3\n" +
                 "    ok 4 .4\n" +
-                "  ok 2 .2\n" +
+                "  ok 1 .1\n" +
                 "    1..3\n" +
                 "    ok 1 .1\n" +
                 "    ok 2 .2\n" +
-                "    ok 3 .3\n";
+                "    ok 3 .3\n" +
+                "  ok 2 .2\n" +
+                "ok 1 1\n";
 
         _test(tap, 7,
                 new String[] {
@@ -97,18 +97,18 @@ public class TestFlattenTapResult {
 
         final String tap =
                 "1..1\n" +
-                "ok 1 1\n" +
                 "  1..2\n" +
-                "  ok 1 .1\n" +
                 "    1..4\n" +
                 "    ok 1 .1\n" +
                 "    ok 2 .2\n" +
                 "    ok 3 .3\n" +
-                "  ok 2 .2\n" +
+                "  ok 1 .1\n" +
                 "    1..3\n" +
                 "    ok 1 .1\n" +
                 "    ok 2 .2\n" +
-                "    ok 3 .3\n";
+                "    ok 3 .3\n" +
+                "  ok 2 .2\n" +
+                "ok 1 1\n";
 
         _test(tap, 7,
                 new String[] {
@@ -120,16 +120,16 @@ public class TestFlattenTapResult {
     public void testStripSecondLevelIncompleteResult2() throws IOException, InterruptedException, ExecutionException {
         final String tap2 =
                 "1..1\n" +
-                "ok 1 1\n" +
                 "  1..2\n" +
-                "  ok 1 .1\n" +
                 "    1..4\n" +
                 "    ok 1 .1\n" +
                 "    ok 2 .2\n" +
                 "    ok 3 .3\n" +
-                "  ok 2 .2\n" +
+                "  ok 1 .1\n" +
                 "    1..3\n" +
-                "    ok 1 .1\n";
+                "    ok 1 .1\n" +
+                "  ok 2 .2\n" +
+                "ok 1 1\n";
 
         _test(tap2, 6,
                 new String[] {

--- a/src/test/java/org/tap4j/plugin/stripsingleparent/TestStripSingleParent.java
+++ b/src/test/java/org/tap4j/plugin/stripsingleparent/TestStripSingleParent.java
@@ -33,11 +33,11 @@ public class TestStripSingleParent {
     public void testNoEffect() throws IOException, InterruptedException, ExecutionException {
 
         final String tap = "1..2\n" +
-                "ok 1 - 1\n" +
                 "  1..3\n" +
                 "  ok 1 1.1\n" +
                 "  ok 2 1.2\n" +
                 "  ok 3 1.3\n" +
+                "ok 1 - 1\n" +
                 "ok 2 - 1\n";
 
         _test(tap, 2);
@@ -47,11 +47,11 @@ public class TestStripSingleParent {
     public void testStripFirstLevel() throws IOException, InterruptedException, ExecutionException {
 
         final String tap = "1..1\n" +
-                "ok 1 - 1\n" +
                 "  1..3\n" +
                 "  ok 1 1.1\n" +
                 "  ok 2 1.2\n" +
-                "  ok 3 1.3\n";
+                "  ok 3 1.3\n" +
+                "ok 1 - 1\n";
 
         _test(tap, 3);
     }
@@ -61,13 +61,13 @@ public class TestStripSingleParent {
 
         final String tap =
                 "1..1\n" +
-                "ok 1 - 1\n" +
                 "  1..1\n" +
-                "  ok 1.1 - 1\n" +
                 "    1..3\n" +
                 "    ok 1 1.1.1\n" +
                 "    ok 2 1.1.2\n" +
-                "    ok 3 1.1.3\n";
+                "    ok 3 1.1.3\n" +
+                "  ok 1.1 - 1\n" +
+                "ok 1 - 1\n";
 
         _test(tap, 3);
     }


### PR DESCRIPTION
This PR should address https://github.com/tupilabs/tap4j/issues/56:
- fixed sub-test related tests
- target JDK version upgraded to 1.8 (as required by tap4j)