### PR TITLE
enabled parsing of TAP documents with corrupted YAML content

### DIFF
--- a/src/main/java/org/tap4j/plugin/TapParser.java
+++ b/src/main/java/org/tap4j/plugin/TapParser.java
@@ -66,13 +66,14 @@ public class TapParser {
     private final Boolean verbose;
     private final Boolean stripSingleParents;
     private final Boolean flattenTheTap;
+    private final Boolean removeYamlIfCorrupted;
 
     private boolean hasFailedTests;
     private boolean parserErrors;
 
     public TapParser(Boolean outputTapToConsole, Boolean enableSubtests, Boolean todoIsFailure,
             Boolean includeCommentDiagnostics, Boolean validateNumberOfTests, Boolean planRequired, Boolean verbose,
-            Boolean stripSingleParents, Boolean flattenTheTap,
+            Boolean stripSingleParents, Boolean flattenTheTap, Boolean removeYamlIfCorrupted,
             PrintStream logger) {
         this.outputTapToConsole = outputTapToConsole;
         this.enableSubtests = enableSubtests;
@@ -84,6 +85,7 @@ public class TapParser {
         this.verbose = verbose;
         this.stripSingleParents = stripSingleParents;
         this.flattenTheTap = flattenTheTap;
+        this.removeYamlIfCorrupted = removeYamlIfCorrupted;
         this.logger = logger;
     }
 
@@ -135,6 +137,10 @@ public class TapParser {
         return flattenTheTap;
     }
 
+    public Boolean getRemoveYamlIfCorrupted() {
+        return enableSubtests;
+    }
+
     private boolean containsNotOk(TestSet testSet) {
         for (TestResult testResult : testSet.getTestResults()) {
             if (testResult.getStatus().equals(StatusValues.NOT_OK) && !(testResult.getDirective() != null
@@ -148,7 +154,7 @@ public class TapParser {
     public TapResult parse(FilePath[] results, Run build) {
         this.parserErrors = Boolean.FALSE;
         this.hasFailedTests = Boolean.FALSE;
-        final List<TestSetMap> testSets = new LinkedList<TestSetMap>();
+        final List<TestSetMap> testSets = new LinkedList<>();
         if (null == results) {
             log("File paths not specified. paths var is null. Returning empty test results.");
         } else {
@@ -163,7 +169,7 @@ public class TapParser {
                 try {
                     log("Parsing TAP test result [" + tapFile + "].");
 
-                    final Tap13Parser parser = new Tap13Parser("UTF-8", enableSubtests, planRequired);
+                    final Tap13Parser parser = new Tap13Parser("UTF-8", enableSubtests, planRequired, removeYamlIfCorrupted);
                     final TestSet testSet = flattenTheSetAsRequired(stripSingleParentsAsRequired(parser.parseFile(tapFile)));
 
                     if (containsNotOk(testSet) || testSet.containsBailOut()) {

--- a/src/main/resources/org/tap4j/plugin/TapPublisher/config.jelly
+++ b/src/main/resources/org/tap4j/plugin/TapPublisher/config.jelly
@@ -44,6 +44,9 @@
           <f:checkbox title="Flatten TAP result" name="TapPublisher.flattenTapResult" value="${instance.flattenTapResult}" checked="${instance.flattenTapResult}" default="false" />
       </f:entry>
       <f:entry>
+          <f:checkbox title="Remove corrupted YAML" name="TapPublisher.removeYamlIfCorrupted" value="${instance.removeYamlIfCorrupted}" checked="${instance.removeYamlIfCorrupted}" default="false" />
+      </f:entry>
+      <f:entry>
           <f:checkbox title="Skip if build not successful" help="/plugin/tap/help/TapPublisher/help-skipIfBuildNotOk.html" name="TapPublisher.skipIfBuildNotOk" value="${instance.skipIfBuildNotOk}" checked="${instance.skipIfBuildNotOk}" default="false" />
       </f:entry>
   </f:advanced>

--- a/src/test/java/org/tap4j/plugin/removeyamlifcorrupted/TestRemoveYamlIfCorrupted.java
+++ b/src/test/java/org/tap4j/plugin/removeyamlifcorrupted/TestRemoveYamlIfCorrupted.java
@@ -1,0 +1,121 @@
+package org.tap4j.plugin.removeyamlifcorrupted;
+
+import hudson.Launcher;
+import hudson.model.BuildListener;
+import hudson.model.FreeStyleBuild;
+import hudson.model.AbstractBuild;
+import hudson.model.FreeStyleProject;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestBuilder;
+import org.tap4j.plugin.TapPublisher;
+import org.tap4j.plugin.TapResult;
+import org.tap4j.plugin.TapTestResultAction;
+
+/**
+ * Tests for remove corrupted yaml configuration option.
+ *
+ * @author Jakub Podlesak
+ */
+public class TestRemoveYamlIfCorrupted {
+
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
+
+    @Test
+    public void testYamlStripped() throws IOException, InterruptedException, ExecutionException {
+
+        final String tap = "1..1\n"
+                + "not ok 1 '0' should not be in window anymore\n"
+                + "  ---\n"
+                + "    type:    AssertionError\n"
+                + "    message: '0' should not be in window anymore\n"
+                + "    code:    ~\n"
+                + "    errno:   ~\n"
+                + "    file:    /workdir/npm-module/test/window/frame.js\n"
+                + "    line:    416\n"
+                + "    column:  10\n"
+                + "    stack:\n"
+                + "      - |\n"
+                + "        Object.remove frame (/workdir/npm-module/test/window/frame.js:416:10)\n"
+                + "      - |\n"
+                + "        Object.<anonymous> (/workdir/npm-module/node_modules/nodeunit/lib/core.js:236:16)\n"
+                + "      - |\n"
+                + "        Object.<anonymous> (/workdir/npm-module/node_modules/nodeunit/lib/core.js:236:16)\n"
+                + "      - |\n"
+                + "        /workdir/npm-module/node_modules/nodeunit/lib/core.js:236:16\n"
+                + "      - |\n"
+                + "        Object.runTest (/workdir/npm-module/node_modules/nodeunit/lib/core.js:70:9)\n"
+                + "      - |\n"
+                + "        /workdir/npm-module/node_modules/nodeunit/lib/core.js:118:25\n"
+                + "      - |\n"
+                + "        /workdir/npm-module/node_modules/nodeunit/deps/async.js:513:13\n"
+                + "      - |\n"
+                + "        iterate (/workdir/npm-module/node_modules/nodeunit/deps/async.js:123:13)\n"
+                + "      - |\n"
+                + "        /workdir/npm-module/node_modules/nodeunit/deps/async.js:134:25\n"
+                + "      - |\n"
+                + "        /workdir/npm-module/node_modules/nodeunit/deps/async.js:515:17\n"
+                + "      - |\n"
+                + "        Immediate.<anonymous> (/workdir/npm-module/node_modules/nodeunit/lib/types.js:146:17)\n"
+                + "      - |\n"
+                + "        runCallback (timers.js:693:18)\n"
+                + "      - |\n"
+                + "        tryOnImmediate (timers.js:664:5)\n"
+                + "      - |\n"
+                + "        process.processImmediate (timers.js:646:5)\n"
+                + "    wanted:  true\n"
+                + "    found:   false\n"
+                + "  ...";
+
+        _test("do-not-remove-corrupted-yaml", false, tap, 0);
+        _test("remove-corrupted-yaml", true, tap, 1);
+    }
+
+    private void _test(String projectName, boolean removeYamlIfCorrupted, final String tap, int expectedTotal) throws IOException, InterruptedException, ExecutionException {
+        FreeStyleProject project = jenkins.createProject(FreeStyleProject.class, projectName);
+
+        project.getBuildersList().add(new TestBuilder() {
+            @Override
+            public boolean perform(AbstractBuild<?, ?> build, Launcher arg1,
+                    BuildListener arg2) throws InterruptedException, IOException {
+                build.getWorkspace().child("result.tap").write(tap, "UTF-8");
+                return true;
+            }
+        });
+
+        TapPublisher publisher = new TapPublisher(
+                "result.tap", // test results
+                true, // failIfNoResults
+                true, // failedTestsMarkBuildAsFailure
+                false, // outputTapToConsole
+                true, // enableSubtests
+                true, // discardOldReports
+                true, // todoIsFailure
+                true, // includeCommentDiagnostics
+                true, // validateNumberOfTests
+                true, // planRequired
+                false, // verbose
+                true, // showOnlyFailures
+                false, // stripSingleParents
+                true, // flattenTapResult
+                removeYamlIfCorrupted,
+                false); //skipIfBuildNotOk
+
+        project.getPublishersList().add(publisher);
+        project.save();
+        FreeStyleBuild build = (FreeStyleBuild) project.scheduleBuild2(0).get();
+
+        TapTestResultAction action = build.getAction(TapTestResultAction.class);
+        TapResult testResult = action.getTapResult();
+
+        assertEquals(expectedTotal, testResult.getTotal());
+    }
+}

--- a/src/test/java/org/tap4j/plugin/removeyamlifcorrupted/package-info.java
+++ b/src/test/java/org/tap4j/plugin/removeyamlifcorrupted/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Tests corrupted YAML removal feature feature.
+ */
+package org.tap4j.plugin.removeyamlifcorrupted;


### PR DESCRIPTION
The TAP parser should still fail by default if a corrupted YAML content is seen. The new config option , if set, changes the default behavior such that the parser strips out corrupted YAML parts while keeping the original test lines intact.