### PR TITLE
Fixed test result graph rendering and added three new dashboard columns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<tap4j.version>4.4.2</tap4j.version>
 		<junit.plugin.version>1.6</junit.plugin.version>
+                <dashboard.plugin.version>2.0</dashboard.plugin.version>
 		<!-- TODO: remove once FindBugs issues are fixed -->
 		<findbugs.failOnError>false</findbugs.failOnError>
 	</properties>
@@ -110,6 +111,12 @@
 			<artifactId>junit</artifactId>
 			<version>${junit.plugin.version}</version>
 		</dependency>
+                <!-- For dashboard view support -->
+                <dependency>
+                        <groupId>org.jenkins-ci.plugins</groupId>
+                        <artifactId>dashboard-view</artifactId>
+                        <version>${dashboard.plugin.version}</version>
+                </dependency>
 		<!-- Test -->
 		<dependency>
 			<groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/tap4j/plugin/TapResult.java
+++ b/src/main/java/org/tap4j/plugin/TapResult.java
@@ -2,17 +2,17 @@
  * The MIT License
  *
  * Copyright (c) 2011 Bruno P. Kinoshita
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -189,6 +189,9 @@ public class TapResult implements ModelObject, Serializable {
 
         for (TestSetMap testSet : testSets) {
             TestSet realTestSet = testSet.getTestSet();
+            if (realTestSet == null) {
+                continue;
+            }
             List<TestResult> testResults = realTestSet.getTestResults();
 
             total += testResults.size();
@@ -327,7 +330,7 @@ public class TapResult implements ModelObject, Serializable {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see hudson.model.ModelObject#getDisplayName()
      */
     public String getDisplayName() {

--- a/src/main/java/org/tap4j/plugin/model/TapStreamResult.java
+++ b/src/main/java/org/tap4j/plugin/model/TapStreamResult.java
@@ -2,17 +2,17 @@
  * The MIT License
  *
  * Copyright (c) 2012 Bruno P. Kinoshita
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -58,7 +58,7 @@ public class TapStreamResult extends TabulatedResult {
         this.tapResult = tapResult;
         setChildrenInfo();
     }
-    
+
     /* (non-Javadoc)
      * @see hudson.model.ModelObject#getDisplayName()
      */
@@ -89,7 +89,7 @@ public class TapStreamResult extends TabulatedResult {
     public TestResult findCorrespondingResult(String id) {
         return null;
     }
-    
+
     /* (non-Javadoc)
      * @see hudson.tasks.test.TabulatedResult#getChildren()
      */
@@ -105,7 +105,7 @@ public class TapStreamResult extends TabulatedResult {
     public boolean hasChildren() {
         return children.size() > 0;
     }
-    
+
     /* (non-Javadoc)
      * @see hudson.tasks.test.AbstractTestResultAction#getFailCount()
      */
@@ -123,7 +123,7 @@ public class TapStreamResult extends TabulatedResult {
     public int getTotalCount() {
         return tapResult.getTotal();
     }
-    
+
     /* (non-Javadoc)
      * @see hudson.tasks.test.AbstractTestResultAction#getSkipCount()
      */
@@ -145,16 +145,18 @@ public class TapStreamResult extends TabulatedResult {
         //throw new AssertionError("Not supposed to be called");
         return Collections.emptyList();
     }
-    
+
     // FIXME: use the getFailedTests, or explain why it's not used
     public List<TestResult> getFailedTests2() {
         List<TestResult> failedTests = new ArrayList<TestResult>();
         if(tapResult != null && tapResult.getTestSets().size() > 0) {
             for(TestSetMap tsm : tapResult.getTestSets()) {
                 TestSet ts = tsm.getTestSet();
-                for(org.tap4j.model.TestResult tr : ts.getTestResults()) {
-                    if(tr.getStatus() == StatusValues.NOT_OK) {
-                        failedTests.add(new TapTestResultResult(owner, tsm, tr, this.tapResult.getTodoIsFailure(), tapResult.getIncludeCommentDiagnostics(), tapResult.getValidateNumberOfTests()));
+                if (ts != null) {
+                    for(org.tap4j.model.TestResult tr : ts.getTestResults()) {
+                        if(tr.getStatus() == StatusValues.NOT_OK) {
+                            failedTests.add(new TapTestResultResult(owner, tsm, tr, this.tapResult.getTodoIsFailure(), tapResult.getIncludeCommentDiagnostics(), tapResult.getValidateNumberOfTests()));
+                        }
                     }
                 }
             }
@@ -189,29 +191,31 @@ public class TapStreamResult extends TabulatedResult {
             return null; // we don't allow null, nay!
         if (name.lastIndexOf("-") <= 0)
             return null; // ops, where's the - mate?
-        
+
         name = name.trim();
-        
+
         int rightIndex = name.length();
         while (name.charAt(rightIndex-1) == '/') {
             rightIndex -= 1;
         }
         int leftIndex = name.lastIndexOf('/') +1;
-        
+
         String testResultName = name.substring(leftIndex, rightIndex); // but we want the test result name (testSet1.tap)
         if (testResultName.indexOf('-') <= 0) // plus the number (testSet1.tap-2)
             return null;
         String testNumber = testResultName.substring(testResultName.lastIndexOf('-')+1);
         String fileName = name.substring(0, name.lastIndexOf('-'));
-        
+
         for(TestSetMap tsm : tapResult.getTestSets()) {
             if(tsm.getFileName().equals(fileName)) {
                 TestSet ts = tsm.getTestSet();
-                org.tap4j.model.TestResult desired = ts.getTestResult(Integer.parseInt(testNumber));
-                return new TapTestResultResult(owner, tsm, desired, this.tapResult.getTodoIsFailure(), tapResult.getIncludeCommentDiagnostics(), tapResult.getValidateNumberOfTests());
+                if (ts != null) {
+                    org.tap4j.model.TestResult desired = ts.getTestResult(Integer.parseInt(testNumber));
+                    return new TapTestResultResult(owner, tsm, desired, this.tapResult.getTodoIsFailure(), tapResult.getIncludeCommentDiagnostics(), tapResult.getValidateNumberOfTests());
+                }
             }
         }
-        
+
         return null; // ops, something went wrong
     }
 
@@ -227,8 +231,10 @@ public class TapStreamResult extends TabulatedResult {
     private void setChildrenInfo() {
         for(TestSetMap tsm : tapResult.getTestSets()) {
             TestSet ts = tsm.getTestSet();
-            for(org.tap4j.model.TestResult tr : ts.getTestResults()) {
-                this.children.add(new TapTestResultResult(owner, tsm, tr, tapResult.getTodoIsFailure(), tapResult.getIncludeCommentDiagnostics(), tapResult.getValidateNumberOfTests()));
+            if (ts != null) {
+                for(org.tap4j.model.TestResult tr : ts.getTestResults()) {
+                    this.children.add(new TapTestResultResult(owner, tsm, tr, tapResult.getTodoIsFailure(), tapResult.getIncludeCommentDiagnostics(), tapResult.getValidateNumberOfTests()));
+                }
             }
         }
     }

--- a/src/main/java/org/tap4j/plugin/util/DiagnosticUtil.java
+++ b/src/main/java/org/tap4j/plugin/util/DiagnosticUtil.java
@@ -1,18 +1,18 @@
-/* 
+/*
  * The MIT License
- * 
+ *
  * Copyright (c) 2010 Bruno P. Kinoshita
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -29,7 +29,7 @@ import java.util.Set;
 
 /**
  * Used to create YAML view.
- * 
+ *
  * @author Bruno P. Kinoshita - http://www.kinoshita.eti.br
  * @since 1.0
  */
@@ -55,7 +55,7 @@ public class DiagnosticUtil {
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    public static void createDiagnosticTableRecursively(String tapFile, String parentKey, 
+    public static void createDiagnosticTableRecursively(String tapFile, String parentKey,
             Map<String, Object> diagnostic, StringBuilder sb, int depth) {
 
         sb.append(INNER_TABLE_HEADER);
@@ -67,11 +67,11 @@ public class DiagnosticUtil {
                 String key = entry.getKey();
                 Object value = entry.getValue();
                 sb.append("<tr>");
-    
+
                 for (int i = 0; i < depth; ++i) {
                     sb.append("<td width='5%' class='hidden'> </td>");
                 }
-                sb.append("<td style=\"width: auto;\">" + key + "</td>");
+                sb.append("<td style=\"width: auto;\">").append(key).append("</td>");
                 if(key.equals("File-Content")) {
                     String fileName = "attachment";
                     Object o = diagnostic.get("File-Name");
@@ -84,9 +84,9 @@ public class DiagnosticUtil {
                             downloadKey = parentKey;
                         }
                     }
-                    sb.append("<td><a href='downloadAttachment?f="+tapFile+"&key="+downloadKey+"'>"+fileName+"</a></td>");
+                    sb.append("<td><a href='downloadAttachment?f=").append(tapFile).append("&key=").append(downloadKey).append("'>").append(fileName).append("</a></td>");
                 } else {
-                    sb.append("<td><pre>" + org.apache.commons.lang.StringEscapeUtils.escapeHtml(value.toString()) + "</pre></td>");
+                    sb.append("<td><pre>").append(org.apache.commons.lang.StringEscapeUtils.escapeHtml(value != null ? value.toString() : "")).append("</pre></td>");
                 }
                 sb.append("</tr>");
             }
@@ -95,7 +95,7 @@ public class DiagnosticUtil {
                 String key = entry.getKey();
                 Object value = entry.getValue();
                 sb.append("<tr>");
-    
+
                 for (int i = 0; i < depth; ++i) {
                     sb.append("<td width='5%' class='hidden'> </td>");
                 }
@@ -105,7 +105,7 @@ public class DiagnosticUtil {
                     createDiagnosticTableRecursively(tapFile, key, (java.util.Map) value, sb,
                             (depth + 1));
                 } else {
-                    sb.append("<td><pre>" + org.apache.commons.lang.StringEscapeUtils.escapeHtml(value.toString()) + "</pre></td>");
+                    sb.append("<td><pre>").append(org.apache.commons.lang.StringEscapeUtils.escapeHtml(value != null ? value.toString() : "")).append("</pre></td>");
                 }
                 sb.append("</tr>");
             }

--- a/src/main/java/org/tap4j/plugin/view/TapCompatibilityColumn.java
+++ b/src/main/java/org/tap4j/plugin/view/TapCompatibilityColumn.java
@@ -1,0 +1,130 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019, Jenkins.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.tap4j.plugin.view;
+
+import hudson.Extension;
+import hudson.model.Items;
+import hudson.model.Job;
+import hudson.model.Run;
+import hudson.views.ListViewColumn;
+import hudson.views.ListViewColumnDescriptor;
+import org.acegisecurity.AccessDeniedException;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.tap4j.plugin.TapTestResultAction;
+
+/**
+ * TAP compatibility column for the dashboard view.
+ *
+ * @author Jakub Podlešák, Oracle Labs
+ */
+public class TapCompatibilityColumn extends ListViewColumn {
+
+    private String toReplace;
+    private String newText;
+
+    @DataBoundConstructor
+    public TapCompatibilityColumn(String toReplace, String newText) {
+        super();
+        this.toReplace = toReplace;
+        this.newText = newText;
+    }
+
+    public String getToReplace() {
+        return toReplace;
+    }
+
+    public String getNewText() {
+        return newText;
+    }
+
+
+
+    private boolean configIsValid() {
+        return isValidOption(toReplace) && isValidOption(newText);
+    }
+
+    private boolean isValidOption(String opt) {
+        return opt != null && !opt.isEmpty();
+    }
+
+    public String getCounterpartJobUrl(Job job) {
+        Job<?, ?> theOtherJob = getCounterpartJob(job);
+        return theOtherJob == null ? null : theOtherJob.getAbsoluteUrl();
+    }
+
+    public String getTestCompatibilityStatus(Job<?, ?> job) {
+
+
+        if (!configIsValid()) {
+            return "N/A";
+        }
+
+        Job<?, ?> theOtherJob = getCounterpartJob(job);
+        final TapTestResultAction theOtherLastTapResult = getLastTapResult(theOtherJob);
+
+        final TapTestResultAction lastTapResult = getLastTapResult(job);
+
+        if (lastTapResult == null || theOtherLastTapResult == null) {
+            return "N/A";
+        }
+
+        boolean compatible = (lastTapResult.getTotalCount() == theOtherLastTapResult.getTotalCount()
+                        && lastTapResult.getFailCount() == theOtherLastTapResult.getFailCount()
+                        && lastTapResult.getSkipCount() == theOtherLastTapResult.getSkipCount());
+
+        return compatible ? "COMPATIBLE" : "INCOMPATIBLE";
+    }
+
+    private Job<?, ?> getCounterpartJob(Job<?, ?> job) throws AccessDeniedException {
+        return ViewHelper.getCounterpartJob(job, toReplace, newText);
+    }
+
+    private TapTestResultAction getLastTapResult(Job<?, ?> job) {
+        Run<?, ?> b = job != null ? job.getLastCompletedBuild() : null;
+        return b != null ? b.getAction(TapTestResultAction.class) : null;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends ListViewColumnDescriptor {
+
+        public DescriptorImpl() {
+            Items.XSTREAM2.addCompatibilityAlias("hudson.views.TapCompatibilityColumn", org.tap4j.plugin.view.TapCompatibilityColumn.class);
+        }
+
+        @Override
+        public boolean shownByDefault() {
+            return false;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "TAP compatibility";
+        }
+
+        @Override
+        public String getHelpFile() {
+            return "/plugin/tap/help/TapCompatibilityColumn/config.html";
+        }
+    }
+}

--- a/src/main/java/org/tap4j/plugin/view/TapRegressionColumn.java
+++ b/src/main/java/org/tap4j/plugin/view/TapRegressionColumn.java
@@ -1,0 +1,111 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019, Jenkins.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.tap4j.plugin.view;
+
+import hudson.Extension;
+import hudson.model.Items;
+import hudson.model.Job;
+import hudson.model.Run;
+import hudson.views.ListViewColumn;
+import hudson.views.ListViewColumnDescriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.tap4j.plugin.TapTestResultAction;
+
+/**
+ * TAP regression column for the dashboard view.
+ *
+ * @author Jakub Podlešák, Oracle Labs
+ */
+public class TapRegressionColumn extends ListViewColumn {
+
+    @DataBoundConstructor
+    public TapRegressionColumn() {
+        super();
+    }
+
+    public String getTestRegressionStatus(Job<?, ?> job) {
+
+        final TapTestResultAction lastTapResult = getLastTapResult(job);
+
+        if (lastTapResult == null) {
+            return "N/A";
+        }
+
+        final TapTestResultAction secondLastTapResult = getSecondLastTapResult(job);
+
+        if (secondLastTapResult == null) {
+            return "N/A";
+        }
+
+        final int failedNow = lastTapResult.getFailCount();
+        final int failedBefore = secondLastTapResult.getFailCount();
+        final int totalNow = lastTapResult.getTotalCount();
+        final int totalBefore = secondLastTapResult.getTotalCount();
+
+        if (failedNow == failedBefore && totalNow == totalBefore) {
+            return "STABLE";
+        }
+
+        if (failedNow <= failedBefore && totalNow >= totalBefore) {
+            return "IMPROVED";
+        }
+
+        return "REGRESSED";
+    }
+
+    private TapTestResultAction getLastTapResult(Job<?, ?> job) {
+        Run<?, ?> b = job.getLastCompletedBuild();
+        return b != null ? b.getAction(TapTestResultAction.class) : null;
+    }
+
+    private TapTestResultAction getSecondLastTapResult(Job<?, ?> job) {
+        Run<?, ?> lastBuild = job.getLastCompletedBuild();
+        Run<?, ?> secondLastBuild = lastBuild != null ? lastBuild.getPreviousCompletedBuild() : null;
+        return secondLastBuild != null ? secondLastBuild.getAction(TapTestResultAction.class) : null;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends ListViewColumnDescriptor {
+
+        public DescriptorImpl() {
+            Items.XSTREAM2.addCompatibilityAlias("hudson.views.TapRegressionColumn", org.tap4j.plugin.view.TapRegressionColumn.class);
+        }
+
+        @Override
+        public boolean shownByDefault() {
+            return false;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Regression status";
+        }
+
+        @Override
+        public String getHelpFile() {
+            return "/plugin/tap/help/TapRegressionColumn/config.html";
+        }
+    }
+
+}

--- a/src/main/java/org/tap4j/plugin/view/TapResultColumn.java
+++ b/src/main/java/org/tap4j/plugin/view/TapResultColumn.java
@@ -1,0 +1,81 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019, Jenkins.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.tap4j.plugin.view;
+
+import hudson.Extension;
+import hudson.model.Items;
+import hudson.model.Job;
+import hudson.model.Run;
+import hudson.views.ListViewColumn;
+import hudson.views.ListViewColumnDescriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.tap4j.plugin.TapTestResultAction;
+
+/**
+ * TAP test result counters column for the dashboard view.
+ *
+ * @author Jakub Podlešák, Oracle Labs
+ */
+public class TapResultColumn extends ListViewColumn {
+
+    @DataBoundConstructor
+    public TapResultColumn() {
+        super();
+    }
+
+    public TapTestResultAction getTestResult(Job<?, ?> job) {
+
+        final TapTestResultAction lastTapResult = getLastTapResult(job);
+        return lastTapResult;
+    }
+
+    private TapTestResultAction getLastTapResult(Job<?, ?> job) {
+        Run<?, ?> b = job.getLastCompletedBuild();
+        return b != null ? b.getAction(TapTestResultAction.class) : null;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends ListViewColumnDescriptor {
+
+        public DescriptorImpl() {
+            Items.XSTREAM2.addCompatibilityAlias("hudson.views.TapResultColumn", org.tap4j.plugin.view.TapResultColumn.class);
+        }
+
+        @Override
+        public boolean shownByDefault() {
+            return false;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "TAP counters";
+        }
+
+        @Override
+        public String getHelpFile() {
+            return "/plugin/tap/help/TapResultColumn/config.html";
+        }
+    }
+
+}

--- a/src/main/java/org/tap4j/plugin/view/ViewHelper.java
+++ b/src/main/java/org/tap4j/plugin/view/ViewHelper.java
@@ -1,0 +1,45 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019, Jenkins.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.tap4j.plugin.view;
+
+import hudson.model.Job;
+import jenkins.model.Jenkins;
+import org.acegisecurity.AccessDeniedException;
+
+/**
+ * Helper class for dashboard view related code.
+ *
+ * @author Jakub Podlešák (jakub.podlesak at oracle.com)
+ */
+public class ViewHelper {
+
+    public static Job getCounterpartJob(Job job, String toReplace, String newText) throws AccessDeniedException {
+        Jenkins jenkins = Jenkins.getActiveInstance();
+        String theOtherJobName = job.getName().replaceFirst(toReplace, newText);
+        Job theOtherJob = (Job)jenkins.getItem(theOtherJobName);
+        return theOtherJob;
+    }
+
+
+}

--- a/src/main/resources/org/tap4j/plugin/view/TapCompatibilityColumn/column.jelly
+++ b/src/main/resources/org/tap4j/plugin/view/TapCompatibilityColumn/column.jelly
@@ -1,0 +1,39 @@
+<!--
+The MIT License
+
+Copyright (c) 2019, Jenkins.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+    <j:set var="compatibilityStatus" value="${it.getTestCompatibilityStatus(job)}"/>
+    <j:set var="counterpartJobUrl" value="${it.getCounterpartJobUrl(job)}"/>
+
+        <j:choose>
+          <j:when test="${counterpartJobUrl == null}">
+            <td>${compatibilityStatus}</td>
+          </j:when>
+          <j:otherwise>
+            <td><a href="${counterpartJobUrl}">${compatibilityStatus}</a></td>
+          </j:otherwise>
+        </j:choose>
+
+</j:jelly>

--- a/src/main/resources/org/tap4j/plugin/view/TapCompatibilityColumn/columnHeader.jelly
+++ b/src/main/resources/org/tap4j/plugin/view/TapCompatibilityColumn/columnHeader.jelly
@@ -1,0 +1,28 @@
+<!--
+The MIT License
+
+Copyright (c) 2019, Jenkins.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+     <th tooltip="${%Test result compatibility status}">${%Compatible}</th>
+</j:jelly>

--- a/src/main/resources/org/tap4j/plugin/view/TapCompatibilityColumn/config.jelly
+++ b/src/main/resources/org/tap4j/plugin/view/TapCompatibilityColumn/config.jelly
@@ -1,0 +1,46 @@
+<!--
+  The MIT License
+
+  Copyright (c) 2019, Jenkins.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
+    xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
+    xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
+    <f:block>
+
+        <table>
+            <tr>
+                <td colspan="3">${%This column will show if test result of the last build is compatible with test result of it's counterpart job, as defined by job name convention.}</td>
+            </tr>
+            <f:block>
+                <f:entry title="${%replaced text}">
+                    <f:textbox field="toReplace" default="" />
+                </f:entry>
+                <f:entry title="${%replace with}">
+                    <f:textbox field="newText" default="" />
+                </f:entry>
+            </f:block>
+        </table>
+
+    </f:block>
+</j:jelly>

--- a/src/main/resources/org/tap4j/plugin/view/TapRegressionColumn/column.jelly
+++ b/src/main/resources/org/tap4j/plugin/view/TapRegressionColumn/column.jelly
@@ -1,0 +1,30 @@
+<!--
+The MIT License
+
+Copyright (c) 2019, Jenkins.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+    <j:set var="regressionStatus" value="${it.getTestRegressionStatus(job)}"/>
+
+    <td>${regressionStatus}</td>
+</j:jelly>

--- a/src/main/resources/org/tap4j/plugin/view/TapRegressionColumn/columnHeader.jelly
+++ b/src/main/resources/org/tap4j/plugin/view/TapRegressionColumn/columnHeader.jelly
@@ -1,0 +1,28 @@
+<!--
+The MIT License
+
+Copyright (c) 2019, Jenkins.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+     <th tooltip="${%Test regression status. Last and second last completed builds are taken into account.}">${%Regression status}</th>
+</j:jelly>

--- a/src/main/resources/org/tap4j/plugin/view/TapRegressionColumn/config.jelly
+++ b/src/main/resources/org/tap4j/plugin/view/TapRegressionColumn/config.jelly
@@ -1,0 +1,36 @@
+<!--
+  The MIT License
+
+  Copyright (c) 2019, Jenkins.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
+    xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
+    xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
+    <f:block>
+        <table>
+            <tr>
+                <td colspan="3">${%This column shows stability of the builds in terms of TAP result counters.}</td>
+            </tr>
+        </table>
+    </f:block>
+</j:jelly>

--- a/src/main/resources/org/tap4j/plugin/view/TapResultColumn/column.jelly
+++ b/src/main/resources/org/tap4j/plugin/view/TapResultColumn/column.jelly
@@ -1,0 +1,34 @@
+<!--
+The MIT License
+
+Copyright (c) 2019, Jenkins.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+    <j:set var="tr" value="${it.getTestResult(job)}"/>
+    <j:set var="testCount" value="${tr.totalCount}"/>
+    <j:set var="failedCount" value="${tr.failCount}"/>
+    <j:set var="skippedCount" value="${tr.skipCount}"/>
+    <j:set var="passedCount" value="${tr.totalCount-tr.failCount-tr.skipCount}"/>
+
+    <td>${passedCount}/${failedCount}/${testCount}</td>
+</j:jelly>

--- a/src/main/resources/org/tap4j/plugin/view/TapResultColumn/columnHeader.jelly
+++ b/src/main/resources/org/tap4j/plugin/view/TapResultColumn/columnHeader.jelly
@@ -1,0 +1,28 @@
+<!--
+The MIT License
+
+Copyright (c) 2019, Jenkins.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+     <th tooltip="${%Test result of latest build}">${%Test Result}</th>
+</j:jelly>

--- a/src/main/resources/org/tap4j/plugin/view/TapResultColumn/config.jelly
+++ b/src/main/resources/org/tap4j/plugin/view/TapResultColumn/config.jelly
@@ -1,0 +1,36 @@
+<!--
+  The MIT License
+
+  Copyright (c) 2019, Jenkins.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
+    xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
+    xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
+    <f:block>
+        <table>
+            <tr>
+                <td colspan="3">${%This column shows test result counters of the last build.}</td>
+            </tr>
+        </table>
+    </f:block>
+</j:jelly>

--- a/src/main/webapp/help/TapCompatibilityColumn/config.html
+++ b/src/main/webapp/help/TapCompatibilityColumn/config.html
@@ -1,0 +1,38 @@
+<!--
+The MIT License
+
+Copyright (c) 2019, Jenkins.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<div>
+    This column provides quick information on test result compatibility with another job. <br/>
+  In order to be able to leverage this feature, you need to stick with a simple name convention,
+  where corresponding jobs follow certain naming pattern. <br/>
+  You could e.g. have the following jobs:
+  <table>
+      <tr><th>job name</th><th>description</th></tr>
+      <tr><td>FeatureA-nightly</td><td>test for feature A running on your nightly builds</td></tr>
+      <tr><td>FeatureB-nightly</td><td>test for feature B running on your nightly builds</td></tr>
+      <tr><td>FeatureA-golden</td><td>build that generates golden (desired, probably made up) result TAP file, for feature A</td></tr>
+      <tr><td>FeatureB-golden</td><td>dtto (golden file generator) for feature B</td></tr>
+  </table>
+  Then to quickly see if your nightly builds are compatible with desired results, simply add this column and set <code>nightly</code> to be replaced with <code>golden</code> in the following form:
+</div>

--- a/src/main/webapp/help/TapRegressionColumn/config.html
+++ b/src/main/webapp/help/TapRegressionColumn/config.html
@@ -1,0 +1,27 @@
+<!--
+The MIT License
+
+Copyright (c) 2019, Jenkins.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<div>
+  This column shows if TAP test counters of the last build (failed/total) are in accord with the previous build.<br/>
+</div>

--- a/src/main/webapp/help/TapResultColumn/config.html
+++ b/src/main/webapp/help/TapResultColumn/config.html
@@ -1,0 +1,27 @@
+<!--
+The MIT License
+
+Copyright (c) 2019, Jenkins.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<div>
+  This column shows the TAP test counters of the last build (passed/failed/total).<br/>
+</div>


### PR DESCRIPTION
This PR addresses issues caused by various NPEs coming from trend graph rendering logic that i experienced while using TAP plugin in our local deployment for NPM package testing.

The PR also introduces several dashboard view columns that help with propagating test counter related information to the view and also help with determining compliance of selected jobs with given "golden" scenario based on test counter values.

Attaching several screenshots to illustrate the functionality added:

Config page of the view named "test":
![config](https://user-images.githubusercontent.com/430656/58968292-1b1a0b00-87b6-11e9-9744-16f4a3f6b045.png)

Golden, base line, project in a view:
![golden-baseline](https://user-images.githubusercontent.com/430656/58967527-a4304280-87b4-11e9-80bf-5a3b9f114b93.png)

Test project "initial", incompatible, state:
![tap-test-project-1](https://user-images.githubusercontent.com/430656/58967716-fa04ea80-87b4-11e9-841b-15f95e66fd9e.png)

Corresponding dashboard view:
![tap-dashboard1](https://user-images.githubusercontent.com/430656/58967786-1d2f9a00-87b5-11e9-8368-bdc1754c2dcb.png)

Test project stabilized:
![tap-test-project-stabilized](https://user-images.githubusercontent.com/430656/58967835-39333b80-87b5-11e9-8c31-22689ecbb77d.png)
![tap-dashboard2](https://user-images.githubusercontent.com/430656/58967863-451efd80-87b5-11e9-84d3-9189ba766814.png)

Test project, clean run:
![tap-test-project-clean-run](https://user-images.githubusercontent.com/430656/58967933-6849ad00-87b5-11e9-8b5c-0482f0fc6745.png)
![tap-dashboard3](https://user-images.githubusercontent.com/430656/58967942-6da6f780-87b5-11e9-8390-8e633053ceee.png)

Test project back to compatible state:
![tap-test-project-back-to-compatible](https://user-images.githubusercontent.com/430656/58967974-7ef00400-87b5-11e9-8644-b48a6e35b402.png)
![tap-dashboard4](https://user-images.githubusercontent.com/430656/58967980-82838b00-87b5-11e9-8ce3-24e143544ac2.png)


