### PR TITLE
Adapt icon path removal from core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ test-output/
 .settings/
 .project
 **/*~
+.idea

--- a/src/main/resources/org/tap4j/plugin/TapProjectAction/sidepanel.jelly
+++ b/src/main/resources/org/tap4j/plugin/TapProjectAction/sidepanel.jelly
@@ -1,10 +1,9 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:
-fmt">
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
   <l:header />
   <l:side-panel>
     <l:tasks>
-      <l:task icon="images/24x24/up.gif" href="${rootURL}/" title="${%Back to Dashboard}" />
+      <l:task icon="icon-up icon-md" href="${rootURL}/" title="${%Back to Dashboard}" />
     </l:tasks>
   </l:side-panel>
 </j:jelly>

--- a/src/main/resources/org/tap4j/plugin/TapTestResultAction/sidepanel.jelly
+++ b/src/main/resources/org/tap4j/plugin/TapTestResultAction/sidepanel.jelly
@@ -39,10 +39,10 @@ THE SOFTWARE.
       <t:actions actions="${it.testActions}" />
 
       <j:if test="${it.owner.previousBuild!=null}">
-        <l:task icon="images/24x24/previous.png" href="${buildUrl.previousBuildUrl}" title="${%Previous Build}" />
+        <l:task icon="icon-previous icon-md" href="${buildUrl.previousBuildUrl}" title="${%Previous Build}" />
       </j:if>
       <j:if test="${it.owner.nextBuild!=null}">
-        <l:task icon="images/24x24/next.png" href="${buildUrl.nextBuildUrl}" title="${%Next Build}" />
+        <l:task icon="icon-next icon-md" href="${buildUrl.nextBuildUrl}" title="${%Next Build}" />
       </j:if>
     </l:tasks>
   </l:side-panel>


### PR DESCRIPTION
The change proposed prepares the plugin for the icon path removal from core in the upcoming LTS line. This change affects plugins not using the icon API or relying on paths. Plugins using the API properly in the first place are unaffected by this change.

Could you trigger a release after merging this PR please, giving people a chance to update the plugin before updating to the next LTS version @kinow 
Thanks in advance!