### PR TITLE
WIP - Moved pom.xml to current jenkins levels

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
 		<!-- First LTS which includes OptionalJobProperty. -->
-		<version>3.2</version>
+		<version>4.55</version>
 	</parent>
 
 	<inceptionYear>2011</inceptionYear>
@@ -50,13 +50,9 @@
 	</organization>
 
 	<properties>
-		<jenkins.version>1.642.3</jenkins.version>
-		<java.level>8</java.level>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<jenkins.version>2.361.4</jenkins.version>
 		<tap4j.version>4.4.2</tap4j.version>
 		<junit.plugin.version>1.6</junit.plugin.version>
-		<!-- TODO: remove once FindBugs issues are fixed -->
-		<findbugs.failOnError>false</findbugs.failOnError>
 	</properties>
 
 	<issueManagement>
@@ -109,26 +105,6 @@
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>junit</artifactId>
 			<version>${junit.plugin.version}</version>
-		</dependency>
-		<!-- Test -->
-		<dependency>
-			<groupId>org.jenkins-ci.plugins.workflow</groupId>
-			<artifactId>workflow-job</artifactId>
-			<version>2.5</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.jenkins-ci.plugins.workflow</groupId>
-			<artifactId>workflow-cps</artifactId>
-			<version>2.12</version>
-			<scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<!-- Jenkins core bundles older version -->
-					<groupId>org.jenkins-ci</groupId>
-					<artifactId>annotation-indexer</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
This PR moved pom.xml to  current century, and I'm pretty sure the chanegs should be correct.
However there are testfailures and spotbugs failures. Both can be disabled from cmdline (-Dspotbugs.skip=true, spotbugs no longer from pom) but none want to do that :). In addition, it is removing jdk8 support (which is good).

It would be nice to bump also tap4j dependence and thus  also junit.plugin.version but that made even bigger mayhem.

The spotbugs issue seems to be easy to fix, but with the tests I'm not so sure:(

Thus saying, this PR may remain as WIP until somone a bit more experiecned picks  up, or untill I slowly finish it ot untill tap plugin will no longer be installable due to to old dependencies.
