### PR TITLE
Added interactive navigations to quickly find failed tests and reasons

### DIFF
--- a/src/main/java/org/tap4j/plugin/TapResult.java
+++ b/src/main/java/org/tap4j/plugin/TapResult.java
@@ -296,6 +296,14 @@ public class TapResult implements ModelObject, Serializable {
         return this.bailOuts;
     }
 
+    public int getComments() {
+        int count = 0;
+        for (TestSetMap testSet: testSets) {
+            count += testSet.getTestSet().getComments().size();
+        }
+        return count;
+    }
+
     public int getTotal() {
         return this.total;
     }
@@ -308,10 +316,11 @@ public class TapResult implements ModelObject, Serializable {
      * Called from TapResult/index.jelly
      * @param tapFile location of TAP file
      * @param diagnostic TAP diagnostics
+     * @param tapLine TAP origin of the diagnsotic table
      * @return diagnostic table
      */
-    public String createDiagnosticTable(String tapFile, Map<String, Object> diagnostic) {
-        return DiagnosticUtil.createDiagnosticTable(tapFile, diagnostic);
+    public String createDiagnosticTable(String tapFile, Map<String, Object> diagnostic, TestResult tapLine) {
+        return DiagnosticUtil.createDiagnosticTable(tapFile, diagnostic, tapLine);
     }
 
     /**
@@ -439,4 +448,25 @@ public class TapResult implements ModelObject, Serializable {
         }
         return null;
     }
+
+    //Used in jelly
+    public String getClazz(BailOut tapLine) {
+        return "_bailout_";
+    }
+
+    //Used in jelly
+    public String getClazz(Comment tapLine) {
+        return "_comment_";
+    }
+
+    //Used in jelly
+    public String getClazz(TestResult tapLine) {
+        return Util.getClazz("test_", tapLine);
+    }
+
+    //Used in jelly
+    public String getId(TestResult tapLine, String file) {
+        return  Util.getId("", tapLine, file);
+    }
+
 }

--- a/src/main/java/org/tap4j/plugin/util/Util.java
+++ b/src/main/java/org/tap4j/plugin/util/Util.java
@@ -23,6 +23,7 @@
  */
 package org.tap4j.plugin.util;
 
+import org.apache.commons.lang.StringEscapeUtils;
 import org.tap4j.model.Directive;
 import org.tap4j.model.TestResult;
 import org.tap4j.util.DirectiveValues;
@@ -91,5 +92,14 @@ public final class Util {
             r = true;
         }
         return r;
+    }
+
+    public static String getClazz(String prefix, TestResult tapLine) {
+        return StringEscapeUtils.escapeHtml((prefix + tapLine.getStatus() + (tapLine.getDirective() == null ? "" :
+                "_" + tapLine.getDirective().getDirectiveValue())).replaceAll("\\s+", "_"));
+    }
+
+    public static String getId(String prefix, TestResult tapLine, String file) {
+        return StringEscapeUtils.escapeHtml((prefix + file + "_" + tapLine.getTestNumber() + "_" + tapLine.getDescription()).replaceAll("\\s+", "_"));
     }
 }

--- a/src/main/resources/org/tap4j/plugin/TapResult/index.jelly
+++ b/src/main/resources/org/tap4j/plugin/TapResult/index.jelly
@@ -16,6 +16,13 @@
 
 				<h1>TAP Extended Test Results</h1>
 
+				<script src="${rootURL}/plugin/tap/interactive.js"/>
+				<script>
+					<![CDATA[
+					//to preset state of buttons (which will corresponmd proeprly to correctly missing elements)
+					window.addEventListener('load', extendedTapsetInteractives().fixButtons, false);
+					]]>
+				</script>
 				<j:choose>
 					<j:when test="${it.isEmptyTestSet()}">
 						<p>Empty test set</p>
@@ -23,12 +30,131 @@
 					<j:otherwise>
 						${it.updateStats()}
 						<table width='100%'>
-							<tr>
-								<td width='5%'>${it.testSets.size()} files</td>
-								<td>${it.getTotal()} tests, ${it.passed} ok, ${it.failed} not ok, ${it.skipped} skipped, ${it.toDo} ToDo, ${it.bailOuts} Bail Out!</td>
-							</tr>
-						</table>
-
+						<tr>
+							<td width='5%'>${it.testSets.size()} files</td>
+							<td>
+								${it.getTotal()} tests,
+								${it.passed} ok,
+								${it.failed} not ok,
+								${it.skipped} skipped,
+								${it.toDo} ToDo
+								<j:if test="${it.includeCommentDiagnostics}">
+								${it.getComments()} comments
+								</j:if>
+								${it.bailOuts} Bail Out!
+							</td>
+							<td>
+							</td>
+						</tr>
+					    <tr>
+							<td>
+								invert:
+							</td>
+							<td>
+								<span class="tapItooltip">
+									<span class='tapIclick tapseExtendedReleased'
+										  id='okTestsButton'
+										  onclick='extendedTapsetInteractives().showHideOk()' >
+										ok tests
+									</span>
+									<span class="tapItooltiptext">click to show/hide ${it.passed} passed tests</span>
+								</span>
+								<span class="tapItooltip">
+									<span class='tapIclick tapseExtendedReleased'
+										  id='notOkTestsButton'
+										  onclick='extendedTapsetInteractives().showHideNotOk()'>
+										not ok tests
+									</span>
+									<span class="tapItooltiptext">click to show/hide ${it.failed} failed tests</span>
+								</span>
+								<span class="tapItooltip">
+									<span class='tapIclick tapseExtendedReleased'
+										  id='skippedTestsButton'
+										  onclick='extendedTapsetInteractives().showHideSkips()'>
+										skipped tests
+									</span>
+									<span class="tapItooltiptext">click to show/hide ${it.skipped} skipped tests</span>
+								</span>
+								<span class="tapItooltip">
+									<span class='tapIclick tapseExtendedReleased'
+										  id='todoTestsButton'
+										  onclick='extendedTapsetInteractives().showHideTodos()'>
+										ToDo tests
+									</span>
+									<span class="tapItooltiptext">click to show/hide ${it.toDo} ToDo tests</span>
+								</span>
+								<j:if test="${it.includeCommentDiagnostics}">
+									<span class="tapItooltip">
+										<span class='tapIclick tapseExtendedReleased'
+											  id='commentsTestsButton'
+											  onclick='extendedTapsetInteractives().showHideComments()'>
+											comments
+										</span>
+										<span class="tapItooltiptext">click to show/hide ${it.getComments()} comments</span>
+									</span>
+								</j:if>
+								<span class="tapItooltip">
+									<span class='tapIclick tapseExtendedReleased'
+										  id='bailedTestsButton'
+									      onclick='extendedTapsetInteractives().showHideBails()'>
+										bailed out tests
+									</span>
+									<span class="tapItooltiptext">click to show/hide ${it.bailOuts} bailed out tests</span>
+								</span>
+								<span class="tapItooltip">
+									<span class='tapIclick tapseExtendedReleased'
+										  id='detailRowsTestsButton'
+										  onclick='extendedTapsetInteractives().showHideDetailsRows()'>
+										details row
+									</span>
+									<span class="tapItooltiptext">click to show/hide whole detail rows. Note it is independent on test header</span>
+								</span>
+								<span class="tapItooltip">
+									<span class='tapIclick tapseExtendedReleased'
+										  id='detailsTestsButton'
+										  onclick='extendedTapsetInteractives().showHideDetails()'>
+										details content
+									</span>
+									<span class="tapItooltiptext">click to show/hide individual detail messages</span>
+								</span>
+								<span class="tapItooltip">
+									<span class='tapIclick tapseExtendedReleased'
+										  id='plusMinusTestsButton'
+										  onclick='extendedTapsetInteractives().showHideInline("jsPM")'>
+										+/-
+									</span>
+									<span class="tapItooltiptext">
+										click to show/hide the expandable +/- element
+									</span>
+								</span>
+							</td>
+							<td>
+								<i class="jsPM">preset-views:
+									<span class="tapItooltip">
+										<u class='tapIclick' onclick='extendedTapsetInteractives().showFailed()'>failed</u><j:whitespace> / </j:whitespace>
+										<span class="tapItooltiptext">list only failed tests (without output)</span>
+									</span>
+									<span class="tapItooltip">
+										<u class='tapIclick' onclick='extendedTapsetInteractives().showFailedDetails()'>failed details</u><j:whitespace> / </j:whitespace>
+										<span class="tapItooltiptext">show only failed tests with all output</span>
+									</span>
+									<span class="tapItooltip">
+										<u class='tapIclick' onclick='extendedTapsetInteractives().hideDetails()'>no details</u><j:whitespace> / </j:whitespace>
+										<span class="tapItooltiptext">hide details of each row</span>
+									</span>
+									<span class="tapItooltip">
+										<u class='tapIclick' onclick='extendedTapsetInteractives().showNothing()'>nothing</u><j:whitespace> / </j:whitespace>
+										<span class="tapItooltiptext">hide all</span>
+									</span>
+									<span class="tapItooltip">
+										<u class='tapIclick' onclick='extendedTapsetInteractives().showAll()'>all</u>
+										<span class="tapItooltiptext">show all</span>
+									</span>
+								</i>
+							</td>
+						</tr>
+					</table>
+				    
 						<j:if test="${it.showOnlyFailures}">
 							<p><strong>Note:</strong> Displaying only failures</p>
 						</j:if>

--- a/src/main/resources/org/tap4j/plugin/tags/line.jelly
+++ b/src/main/resources/org/tap4j/plugin/tags/line.jelly
@@ -20,20 +20,21 @@
 						</j:if>
             		</j:if>
             		<j:if test="${hide == 'false'}">
-					    <tr>
+					    <tr class="${it.getClazz(tapLine)}" id="${it.getId(tapLine,tapFile)}">
 					        <tap:status testResult="${tapLine}" />
-					        <td width="5%" class="center">${tapLine.testNumber}</td>
-					        <td width="65%">${tapLine.description}</td>
+							<!-- If anchor ends with space, chromium like browsers are cutting them off-->
+							<td width="5%" class="center"><a href="#${it.getId(tapLine,tapFile)}!" name="${it.getId(tapLine,tapFile)}!">${tapLine.testNumber}</a></td>
+					        <td width="65%">${tapLine.description}  <u class="jsPM" onclick='extendedTapsetInteractives().showHideRowOne("tr_details_${it.getId(tapLine,tapFile)}")'>+/-</u></td>
 					        <tap:directive directive="${tapLine.directive}" />
 					    </tr>
 					    <!-- Comments diagnostics -->
 	                    <!-- tap:comments diagnostic="${tapLine.comments}" /-->
 					    <!-- YAML Diagnostics -->
-	                    <tap:yaml diagnostic="${tapLine.diagnostic}" tapFile="${tapFile}" />
+	                    <tap:yaml diagnostic="${tapLine.diagnostic}" tapFile="${tapFile}" tapLine="${tapLine}" />
 	                </j:if>
 				</j:when>
 				<j:when  test="${it.isBailOut( tapLine )}">
-				    <tr>
+					<tr class="${it.getClazz(tapLine)}">
                         <td class="red center" width="5%"><img src="/plugin/tap/icons/exclamation.png" alt="Bail out! ${tapLine.reason}" title="Bail out! ${tapLine.reason}" /></td>
                         <td width="5%" class="center"> </td>
                         <td width="65%"><span class="red_text bold">Bail out! ${tapLine.reason}</span></td>
@@ -41,7 +42,7 @@
                     </tr>
 				</j:when>
 				<j:when test="${it.isComment( tapLine ) and it.includeCommentDiagnostics}">
-                    <tr>
+                    <tr class="${it.getClazz(tapLine)}">
                         <td></td>
                         <td colspan='3'>
                             # ${it.escapeHTML(tapLine.text)}<br/>

--- a/src/main/resources/org/tap4j/plugin/tags/yaml.jelly
+++ b/src/main/resources/org/tap4j/plugin/tags/yaml.jelly
@@ -7,8 +7,9 @@
 
 		<j:set var="diagnostic" value="${attrs.diagnostic}" />
 		<j:set var="tapFile" value="${attrs.tapFile}" />
+		<j:set var="tapLine" value="${attrs.tapLine}" />
         
-        <j:out value="${ it.createDiagnosticTable( tapFile, diagnostic ) }"/>
+        <j:out value="${ it.createDiagnosticTable( tapFile, diagnostic, tapLine ) }"/>
         
         <!--tr>
             <table width="100%" class="yaml">

--- a/src/main/webapp/css/tap.css
+++ b/src/main/webapp/css/tap.css
@@ -57,3 +57,75 @@ table.yaml td
 border: 1px solid #ccc;
 padding: 2px 4px;
 }
+
+
+.tapIclick {
+  cursor: pointer;
+}
+
+.jsPM {
+  cursor: pointer;
+}
+
+.tapItooltip {
+  position: relative;
+  display: inline-block;
+}
+
+.tapItooltip .tapItooltiptext {
+  visibility: hidden;
+  width: 120px;
+  background-color: #555;
+  color: #fff;
+  text-align: center;
+  border-radius: 6px;
+  padding: 5px 0;
+  position: absolute;
+  z-index: 1000; /*jenkins toplevel bar is 999*/
+  bottom: 125%;
+  left: 50%;
+  margin-left: -60px;
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+
+.tapItooltip .tapItooltiptext::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  margin-left: -5px;
+  border-width: 5px;
+  border-style: solid;
+  border-color: #555 transparent transparent transparent;
+}
+
+.tapItooltip:hover .tapItooltiptext {
+  visibility: visible;
+  opacity: 1;
+}
+
+    .tapseExtendedPushed {
+      box-shadow: 5px 5px 5px lightblue inset;
+      border-style: none;
+      margin:5px;
+      padding:5px;
+      background-color: gray;
+    }
+    .tapseExtendedReleased {
+      box-shadow: 5px 5px 5px lightblue;
+      border-style: none;
+      margin:0px;
+      padding:5px;
+      background-color: lightgray;
+    }
+    .tapseExtendedMixed {
+      box-shadow: 0px 0px;
+      border-style: solid;
+      border-color: lightblue;
+      border-width: 2px;
+      margin:2px;
+      padding:5px;
+      background-color: darkgray;
+    }
+

--- a/src/main/webapp/interactive.js
+++ b/src/main/webapp/interactive.js
@@ -1,0 +1,413 @@
+extendedTapsetInteractives = function () {
+
+  var batchRunning = false;
+
+  /**
+  For all elements of given class,
+  if they are  hidden (display == none) the display is set to block
+  otherwise it is set to none
+  **/
+  function showHideBlock(clazz) {
+    showHide(clazz, 'block')
+  }
+
+  /**
+  For all elements of given class,
+  if they are  hidden (display == none) the display is set to table-row
+  otherwise it is set to none
+  **/
+  function showHideRow(clazz) {
+    showHide(clazz, 'table-row')
+  }
+
+  /**
+  Shortcut method to show/hide prefixed input classes as table-row
+  **/
+  function showHideRowGroup(clazz) {
+    showHideRow("test_" + clazz)
+    showHideRow("tr_details_" + clazz)
+  }
+
+  /**
+  For all elements of given class,
+  if they are  hidden (display == none) the display is set to inline
+  otherwise it is set to none
+  **/
+  function showHideInline(clazz, type) {
+    showHide(clazz, 'inline')
+  }
+
+  /**
+  For all elements of given class,
+  if they are  hidden (display == none) the display is set to given type
+  otherwise it is set to none
+  **/
+  function showHide(clazz, type) {
+    var all = document.getElementsByClassName(clazz);
+    for (var i = 0; i < all.length; i++) {
+      if (all[i].style != null) if (all[i].style.display == 'none') { all[i].style.display = type } else { all[i].style.display = 'none' };
+    }
+    fixButtons();
+  }
+
+  /**
+  For one exact element of given id
+  if it is  hidden (display == none) the display is set to table-row
+  otherwise it is set to none
+  **/
+  function showHideRowOne(id) {
+    showHideOne(id, 'table-row')
+  }
+
+  /**
+  For one exact element of given id
+  if it is  hidden (display == none) the display is set to inline
+  otherwise it is set to none
+  **/
+  function showHideInlineOne(id) {
+    showHideOne(id, 'inline')
+  }
+
+  /**
+  For one exact element of given id
+  if it is  hidden (display == none) the display is set to block
+  otherwise it is set to none
+  **/
+  function showHideBlockOne(id) {
+    showHideOne(id, 'block')
+  }
+
+  /**
+  For one exact element of given id
+  if it is  hidden (display == none) the display is set to given type
+  otherwise it is set to none
+  **/
+  function showHideOne(id, type) {
+    var el = document.getElementById(id);
+    if (el != null && el.style != null) if (el.style.display == 'none') { el.style.display = type } else { el.style.display = 'none' };
+    fixButtons();
+  }
+
+  /**
+  Utility method which set display property of all elements of given class to value of type
+  **/
+  function set(clazz, type) {
+    var all = document.getElementsByClassName(clazz);
+    for (var i = 0; i < all.length; i++) {
+      if (all[i].style != null) {all[i].style.display = type;}
+    }
+    fixButtons();
+  }
+  /**
+    Utility method to show/hide ok rows
+  **/
+  function showHideOk() {
+    showHideRowGroup("ok")
+  }
+
+  /**
+    Utility method to show/hide ok rows
+  **/
+  function showHideNotOk() {
+    showHideRowGroup("not_ok")
+  }
+  /**
+  Utility method tho show/hide various skip declarations
+  **/
+  function showHideSkips() {
+    showHideRowGroup("ok_SKIP")
+    showHideRowGroup("not_ok_SKIP")
+  }
+
+  /**
+  Utility method tho show/hide various todo and details declarations (this is not a todo:)
+  **/
+  function showHideTodos() {
+    showHideRowGroup("ok_TODO")
+    showHideRowGroup("not_ok_TODO")
+  }
+
+  function showHideComments(){
+    showHideRow("_comment_")
+  }
+
+  function showHideBails(){
+    showHideRow("_bailout_")
+  }
+
+  function showHideDetailsRows() {
+    showHideRow("tr_details_ok")
+    showHideRow("tr_details_not_ok")
+  }
+
+  function showHideDetails() {
+    showHideBlock("detail_body")
+  }
+  /**
+  Utility method tho set various skip declarations
+  **/
+  function setSkips(value) {
+      set("test_ok_SKIP", value)
+      set("test_not_ok_SKIP", value)
+  }
+
+  /**
+  Utility method tho set various todo declarations
+  **/
+  function setTodos(value) {
+    set("test_ok_TODO", value)
+    set("test_not_ok_TODO", value)
+  }
+
+  /**
+  Utility method tho set various skip declarations in tables
+  **/
+  function setTrSkips(value) {
+      set("tr_details_ok_SKIP", value)
+      set("tr_details_not_ok_SKIP", value)
+  }
+
+  /**
+  Utility method tho set various todo declarations in tables
+  **/
+  function setTrTodos(value) {
+    set("tr_details_ok_TODO", value)
+    set("tr_details_not_ok_TODO", value)
+  }
+  /**
+  Shortcut method to set display of all not-ok elements to table-row, and none to others
+  **/
+  function showFailed() {
+    batchRunning = true
+    try {
+      set("test_ok", "none")
+      set("test_not_ok", "table-row")
+      set("_bailout_", "table-row")
+      setSkips("none")
+      setTodos("none")
+      set("tr_details_ok", "none")
+      set("tr_details_not_ok", "none")
+      setTrSkips("none")
+      setTrTodos("none")
+      set("_comment_", "none")
+      set("detail_body", "none")
+    } finally {
+      batchRunning=false
+      fixButtons();
+    }
+  }
+
+  /**
+  Shortcut method to set display of all not-ok elements and theirs details to table-row, and none to others
+  **/
+  function showFailedDetails() {
+  batchRunning = true
+    try {
+      set("test_ok", "none")
+      set("test_not_ok", "table-row")
+      set("_bailout_", "table-row")
+      setSkips("none")
+      setTodos("none")
+      set("tr_details_ok", "none")
+      set("tr_details_not_ok", "table-row")
+      setTrSkips("none")
+      setTrTodos("none")
+      set("_comment_", "none")
+      set("detail_body", "block")
+    } finally {
+      batchRunning=false
+      fixButtons();
+    }
+  }
+
+  /**
+  Shortcut method to set display of all not-ok elements and theirs details to table-row, and none to others.
+  ok-skip is set to table-none to hide details body, but keep the its row opened for user-expansion-ondemand
+  **/
+  function hideDetails() {
+    batchRunning = true
+    try{
+      set("test_ok", "none")
+      set("test_not_ok", "table-row")
+      set("_bailout_", "table-row")
+      setSkips("none")
+      setTodos("none")
+      set("tr_details_ok", "none")
+      set("tr_details_not_ok", "table-row")
+      setTrSkips("table-none")
+      setTrTodos("table-none")
+      set("_comment_", "none")
+      set("detail_body", "none")
+    } finally {
+      batchRunning=false
+      fixButtons();
+    }
+  }
+
+  /**
+  Shortcut method to set display of all elements to none
+  **/
+  function showNothing() {
+    batchRunning = true
+    try{
+      set("test_ok", "none")
+      set("test_not_ok", "none")
+      set("_bailout_", "none")
+      setSkips("none")
+      setTodos("none")
+      set("tr_details_ok", "none")
+      set("tr_details_not_ok", "none")
+      setTrSkips("none")
+      setTrTodos("none")
+      set("_comment_", "none")
+      set("detail_body", "none")
+    } finally {
+      batchRunning=false
+      fixButtons();
+    }
+  }
+
+  /**
+  Shortcut method to set display of all elements to block or table-row
+  **/
+  function showAll() {
+    batchRunning = true
+    try {
+      set("test_ok", "table-row")
+      set("test_not_ok", "table-row")
+      set("_bailout_", "table-row")
+      setSkips("table-row")
+      setTodos("table-row")
+      set("tr_details_ok", "table-row")
+      set("tr_details_not_ok", "table-row")
+      setTrSkips("table-row")
+      setTrTodos("table-row")
+      set("_comment_", "table-row")
+      set("detail_body", "block")
+    } finally {
+      batchRunning=false
+      fixButtons();
+    }
+  }
+
+  //you can not pass ..args to another ..args
+  //otherwise one would end in array of arrays
+  //so calling getMultipleClasses directly, requires array on input
+  function getMultipleClasses(args) {
+      var all = new Array();
+      for(let arg of args) {
+        var singleClass = Array.from(document.getElementsByClassName(arg))
+        all = all.concat(singleClass)
+      }
+      var set = new Set(all);
+      const result = [];
+      set.forEach(v => result.push(v)); //Array.from(set) was seen to not work always
+      return result;
+    }
+
+    //-1 all none - all invisible
+    //+1 none none - all visible
+    //0 mixed - some visible, some not (happens mostly for details)
+    function getSelectState(clazz) {
+      var all = getMultipleClasses(clazz);
+      if (all.length == 0) {
+        return 0;
+      }
+      var none = 0;
+      var something = 0;
+      for (var i = 0; i < all.length; i++) {
+        if (all[i].style == null || all[i].style.display == 'none') { none++ } else { something++ };
+      }
+      if (none == all.length) {
+        return -1;
+      } else if (something == all.length) {
+        return 1;
+      } else {
+        return 0;
+      }
+    }
+
+    function setButtonByState(button, state) {
+      if (button == null) {
+        return;
+      }
+      if (state == -1) {
+        button.classList.remove("tapseExtendedMixed")
+        button.classList.remove("tapseExtendedReleased")
+        button.classList.add("tapseExtendedPushed")
+      } else if (state == 1) {
+        button.classList.remove("tapseExtendedMixed")
+        button.classList.remove("tapseExtendedPushed")
+        button.classList.add("tapseExtendedReleased")
+      } else {
+        button.classList.remove("tapseExtendedPushed")
+        button.classList.remove("tapseExtendedReleased")
+        button.classList.add("tapseExtendedMixed")
+      }
+    }
+
+    function fixButtons() {
+      if (batchRunning) {
+        return;
+      }
+      var btn = document.getElementById("okTestsButton");
+      var state = getSelectState(["test_ok"]);
+      setButtonByState(btn, state);
+      var btn = document.getElementById("notOkTestsButton");
+      var state = getSelectState(["test_not_ok"]);
+      setButtonByState(btn, state);
+      var btn = document.getElementById("commentsTestsButton");
+      if (btn!=null) { //comments can be disabeld in settings
+        var state = getSelectState(["_comment_"]);
+        setButtonByState(btn, state);
+      }
+      var btn = document.getElementById("bailedTestsButton");
+      var state = getSelectState(["_bailout_"]);
+      setButtonByState(btn, state);
+      var btn = document.getElementById("detailsTestsButton");
+      var state = getSelectState(["detail_body"]);
+      setButtonByState(btn, state);
+      var btn = document.getElementById("skippedTestsButton");
+      var state = getSelectState(["test_ok_SKIP", "tr_details_ok_SKIP", "test_not_ok_SKIP", "tr_details_not_ok_SKIP"]);
+      setButtonByState(btn, state);
+      var btn = document.getElementById("todoTestsButton");
+      var state = getSelectState(["test_ok_TODO", "tr_details_ok_TODO", "test_not_ok_TODO", "tr_details_not_ok_TODO"]);
+      setButtonByState(btn, state);
+      var btn = document.getElementById("detailRowsTestsButton");
+      var state = getSelectState(["tr_details_ok", "tr_details_not_ok"]);
+      setButtonByState(btn, state);
+
+      var btn = document.getElementById("plusMinusTestsButton");
+      var state = getSelectState(["jsPM"]);
+      setButtonByState(btn, state);
+    }
+
+
+  return {
+    showHideBlock: showHideBlock,
+    showHideRow: showHideRow,
+    showHideOk: showHideOk,
+    showHideNotOk: showHideNotOk,
+    showHideInline: showHideInline,
+    //showHide: showHideRowGroup,showHide,  //no need to publish
+    showHideRowOne: showHideRowOne,
+    showHideInlineOne: showHideInlineOne,
+    showHideBlockOne: showHideBlockOne,
+    showHideOne: showHideOne,
+    //set: set,           //no need to publish
+    showFailed: showFailed,
+    showFailedDetails: showFailedDetails,
+    hideDetails: hideDetails,
+    showNothing: showNothing,
+    showAll: showAll,
+    //setSkips,setTodos,setTrSkips,setTrTodos //no need to publish
+    showHideSkips: showHideSkips,
+    showHideTodos: showHideTodos,
+    showHideComments: showHideComments,
+    showHideBails: showHideBails,
+    showHideDetailsRows: showHideDetailsRows,
+    showHideDetails: showHideDetails,
+    fixButtons:fixButtons
+  }
+
+}

--- a/src/test/java/org/tap4j/plugin/interactive/ExtendedJavascriptActionsInteractiveTests.java
+++ b/src/test/java/org/tap4j/plugin/interactive/ExtendedJavascriptActionsInteractiveTests.java
@@ -1,0 +1,207 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2023 Bruno P. Kinoshita
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.tap4j.plugin.interactive;
+
+import hudson.model.FreeStyleProject;
+import hudson.model.Run;
+import org.htmlunit.html.DomNode;
+import org.htmlunit.html.HtmlPage;
+import org.htmlunit.html.HtmlTableCell;
+import org.htmlunit.html.HtmlTableRow;
+import org.htmlunit.html.HtmlUnderlined;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.tap4j.plugin.TapPublisher;
+import org.w3c.dom.Node;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Check that JS extended page works
+ * https://issues.jenkins.io/browse/JENKINS-73483
+ *
+ * <p>
+ * Debug from inde may not work, due to interactive.js not loaded. If hit, do mvn clean install from cmdline. If nto fixed, run
+ * mvn   -Dtest=ExtendedJavascriptActionsInteractiveTests#testPresetViewsWorks -Dmaven.surefire.debug test
+ * and attach ide's remote dbeug to 5005
+ *
+ * @since 2.X.Y
+ */
+public class ExtendedJavascriptActionsInteractiveTests {
+
+    @Rule
+    public JenkinsRule intJRule = new JenkinsRule();
+
+    public static int[] countVisibleDetailRowsAndBodies(HtmlPage page) {
+        int visibleDetailsRows = 0;
+        int visibleDetailsBodies = 0;
+        List detailsRows = page.getByXPath("//table[@class='tap']/tbody/tr//tr");
+        for (int x = 0; x < detailsRows.size(); x++) {
+            HtmlTableRow tableRow = (HtmlTableRow) (detailsRows.get(x));
+            if (tableRow.isDisplayed()) {
+                visibleDetailsRows++;
+            }
+            HtmlTableCell nameCell2 = tableRow.getCell(2);
+            if (nameCell2.isDisplayed()) {
+                visibleDetailsBodies++;
+            }
+        }
+        return new int[]{visibleDetailsRows, visibleDetailsBodies};
+    }
+
+    @Test
+    @Issue("73483")
+    /**
+     * this test is checking that preset views to they job in hiding/showing proepr elements
+     */
+    public void testPresetViewsWorks() throws IOException, SAXException, ExecutionException, InterruptedException {
+        final FreeStyleProject project = intJRule.createFreeStyleProject();
+        String tapFileName = "suite2.tap";
+        project.getBuildersList().add(ExtendedJavascriptActionsStaticTests.getShell(tapFileName));
+        final TapPublisher tapPublisher = ExtendedJavascriptActionsStaticTests.getSimpleTapPublisher();
+        project.getPublishersList().add(tapPublisher);
+        project.save();
+
+        try (final JenkinsRule.WebClient wc = intJRule.createWebClient()) {
+            wc.setThrowExceptionOnFailingStatusCode(false);
+            Future<?> f = project.scheduleBuild2(0);
+            Run<?, ?> build = (Run<?, ?>) f.get();
+            HtmlPage page = wc.goTo("job/" + project.getName() + "/" + build.getNumber() + "/tapResults/");
+            //all is visible on startup
+            List rowsBeforeClicl = page.getByXPath("//table[@class='tap']/tbody/tr");
+            assertEquals("There should be four tests loaded", 19, rowsBeforeClicl.size());
+            DomNode cellHead = (DomNode) rowsBeforeClicl.get(0);
+            assertEquals("header have no atts", 0, cellHead.getAttributes().getLength());
+            for (int x = 1; x < 19; x++) {
+                DomNode row = (DomNode) rowsBeforeClicl.get(x);
+                String s = row.asXml();
+                Node jsclazz = row.getAttributes().getNamedItem("class");
+                String jsClazzValue = jsclazz.getTextContent();
+                assertEquals("class at row " + x, ExtendedJavascriptActionsStaticTests.classes[x], jsClazzValue);
+                HtmlTableRow tableRow = (HtmlTableRow) row;
+                assertTrue("the element must be visible", tableRow.isDisplayed());
+            }
+            int[] found0 = countVisibleDetailRowsAndBodies(page);
+            assertEquals("all details rows must be visible", 8, found0[0]);
+            assertEquals("all details cells must be visible", 8, found0[1]);
+            //find buttons to click onto
+            ExtendedJavascriptActionsStaticTests.checkInteractiveJs(page);
+            List mainViews = page.getByXPath("//u[@class='tapIclick']");
+            assertEquals("There should be five preset views", 5, mainViews.size());
+            HtmlUnderlined clickable = (HtmlUnderlined) (mainViews.get(0));
+            clickable.click();
+            //only failed
+            List tapRowsAfter1click = page.getByXPath("//table[@class='tap']/tbody/tr");
+            assertEquals("There should be tests loaded", 19, tapRowsAfter1click.size());
+            cellHead = (DomNode) tapRowsAfter1click.get(0);
+            assertEquals("header have no atts", 0, cellHead.getAttributes().getLength());
+            for (int x = 1; x < 19; x++) {
+                DomNode row = (DomNode) tapRowsAfter1click.get(x);
+                String s = row.asXml();
+                Node jsclazz = row.getAttributes().getNamedItem("class");
+                String jsClazzValue = jsclazz.getTextContent();
+                assertEquals("class at row " + x, ExtendedJavascriptActionsStaticTests.classes[x], jsClazzValue);
+                HtmlTableRow tableRow = (HtmlTableRow) row;
+                if (ExtendedJavascriptActionsStaticTests.classes[x].equals("test_not_ok") || ExtendedJavascriptActionsStaticTests.classes[x].equals("_bailout_")) {
+                    assertTrue("the element must be visible " + tableRow, tableRow.isDisplayed());
+                } else {
+                    assertFalse("the element must NOT be visible " + tableRow, tableRow.isDisplayed());
+                }
+            }
+            int[] found1 = countVisibleDetailRowsAndBodies(page);
+            assertEquals("none details rows must be visible", 0, found1[0]);
+            assertEquals("none details cells must be visible", 0, found1[1]);
+
+            clickable = (HtmlUnderlined) (mainViews.get(1));
+            clickable.click();
+            //failed with trace
+            List tapRowsAfter2click = page.getByXPath("//table[@class='tap']/tbody/tr");
+            assertEquals("There should be tests loaded", 19, tapRowsAfter2click.size());
+            cellHead = (DomNode) tapRowsAfter2click.get(0);
+            assertEquals("header have no atts", 0, cellHead.getAttributes().getLength());
+            for (int x = 1; x < 19; x++) {
+                DomNode row = (DomNode) tapRowsAfter2click.get(x);
+                String s = row.asXml();
+                Node jsclazz = row.getAttributes().getNamedItem("class");
+                String jsClazzValue = jsclazz.getTextContent();
+                assertEquals("class at row " + x, ExtendedJavascriptActionsStaticTests.classes[x], jsClazzValue);
+                HtmlTableRow tableRow = (HtmlTableRow) row;
+                if (ExtendedJavascriptActionsStaticTests.classes[x].equals("test_not_ok") ||
+                        ExtendedJavascriptActionsStaticTests.classes[x].equals("_bailout_") ||
+                        ExtendedJavascriptActionsStaticTests.classes[x].equals("tr_details_not_ok")
+                ) {
+                    assertTrue("the element must be visible " + tableRow, tableRow.isDisplayed());
+                } else {
+                    assertFalse("the element must NOT be visible " + tableRow, tableRow.isDisplayed());
+                }
+            }
+            int[] found2 = countVisibleDetailRowsAndBodies(page);
+            assertEquals("none details rows must be visible ", 4, found2[0]);
+            assertEquals("none details cells must be visible ", 4, found2[1]);
+
+            clickable = (HtmlUnderlined) (mainViews.get(2));
+            clickable.click();
+            //failed with trace
+            List tapRowsAfter3click = page.getByXPath("//table[@class='tap']/tbody/tr");
+            assertEquals("There should be tests loaded", 19, tapRowsAfter3click.size());
+            cellHead = (DomNode) tapRowsAfter3click.get(0);
+            assertEquals("header have no atts", 0, cellHead.getAttributes().getLength());
+            for (int x = 1; x < 19; x++) {
+                DomNode row = (DomNode) tapRowsAfter3click.get(x);
+                String s = row.asXml();
+                Node jsclazz = row.getAttributes().getNamedItem("class");
+                String jsClazzValue = jsclazz.getTextContent();
+                assertEquals("class at row " + x, ExtendedJavascriptActionsStaticTests.classes[x], jsClazzValue);
+                HtmlTableRow tableRow = (HtmlTableRow) row;
+                if (ExtendedJavascriptActionsStaticTests.classes[x].equals("test_not_ok") ||
+                        ExtendedJavascriptActionsStaticTests.classes[x].equals("_bailout_") ||
+                        ExtendedJavascriptActionsStaticTests.classes[x].equals("tr_details_not_ok")
+                ) {
+                    assertTrue("the element must be visible " + tableRow, tableRow.isDisplayed());
+                } else {
+                    String style = tableRow.getAttribute("style");
+                    if ("display: table-none;".equals(style)) {
+                        System.err.println("It is invisible just htmluit do not know");
+                    } else {
+                        assertFalse("the element must NOT be visible " + tableRow, tableRow.isDisplayed());
+                    }
+                }
+            }
+            int[] found3 = countVisibleDetailRowsAndBodies(page);
+            assertEquals("none details rows must be visible", 6, found3[0]); //this is weird, it seems it is suffering the same issue with display: table-none as above
+            assertEquals("none details cells must be visible", 0, found3[1]);
+        }
+    }
+
+}

--- a/src/test/java/org/tap4j/plugin/interactive/ExtendedJavascriptActionsStaticTests.java
+++ b/src/test/java/org/tap4j/plugin/interactive/ExtendedJavascriptActionsStaticTests.java
@@ -1,0 +1,397 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2023 Bruno P. Kinoshita
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.tap4j.plugin.interactive;
+
+import hudson.model.FreeStyleProject;
+import hudson.model.Run;
+import hudson.tasks.Shell;
+import org.htmlunit.html.*;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.tap4j.plugin.TapPublisher;
+import org.w3c.dom.Node;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Check that JS and links on extended page contains correct symbols
+ * https://issues.jenkins.io/browse/JENKINS-73483
+ * https://issues.jenkins.io/browse/JENKINS-73484
+ * <p>
+ * Debug from inde may not work, due to interactive.js not loaded. If hit, do mvn clean install from cmdline. If nto fixed, run
+ * mvn   -Dtest=ExtendedJavascriptActionsStaticTests#checkControlIdsExists -Dmaven.surefire.debug test
+ * and attach ide's remote dbeug to 5005
+ *
+ * @since 2.X.Y
+ */
+public class ExtendedJavascriptActionsStaticTests {
+
+    @Rule
+    public JenkinsRule statJRule = new JenkinsRule();
+
+    public static final String[] testIds = {
+            "Input file opened",
+            " First line of the input valid.",
+            "Read the rest of the file",
+            "Summarized correctly1 ", //this trailing space is important, it propagates to id
+            "Summarized correctly2 ", //this trailing space is important, it propagates to id
+            "Summarized correctly3 ", //this trailing space is important, it propagates to id
+            "hi no space1",
+            "hi no space2"
+
+    };
+    public static final String[] classes = {
+            "", //header
+            "_comment_",
+            "_comment_",
+            "_comment_",
+            "test_ok",
+            "tr_details_ok",
+            "test_not_ok",
+            "tr_details_not_ok",
+            "test_not_ok_TODO",
+            "test_not_ok_SKIP",
+            "_comment_",
+            "test_ok_TODO",
+            "tr_details_ok_TODO",
+            "test_ok_SKIP",
+            "_bailout_",
+            "_bailout_",
+            "test_not_ok",
+            "tr_details_not_ok",
+            "test_ok",
+
+    };
+
+
+    public static TapPublisher getSimpleTapPublisher() {
+        return new TapPublisher(
+                "**/*.tap",
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                false,
+                true,
+                false,
+                true,
+                true
+        );
+    }
+
+    public static Shell getShell(String tapFileName) {
+        return new Shell("echo \"" +
+                "# cmnt01\n" +
+                "# cmnt02\n" +
+                "# cmnt03\n" +
+                "1..8\n" +
+                "ok 1 - " + testIds[0] + "\n" +
+                "  ---\n" +
+                "    detailid1: detail1\n" +
+                "    detailid2: detail2\n" +
+                "  ...\n" +
+                "not ok 2 - " + testIds[1] + "\n" +
+                "  ---\n" +
+                "    detailid1: detail3\n" +
+                "    detailid2: detail4\n" +
+                "  ...\n" +
+                "not ok 3 - " + testIds[2] + "# TODO\n" +
+                "not ok 4 - " + testIds[3] + "# skip\n" +
+                "    detailid1: incorrect\n" +
+                "    detailid2: incorrect\n" +
+                "#in results cmnt\n" +
+                "ok 5 - " + testIds[4] + "# TODO Not written yet\n" +
+                "  ---\n" +
+                "    detailid1: detail5\n" +
+                "    detailid2: detail6\n" +
+                "  ...\n" +
+                "ok 6 - " + testIds[5] + "# skip written yet\n" +
+                "Bail out!\n" +
+                "Bail out! with reason\n" +
+                "not ok 7 -" + testIds[6] + "\n" +
+                "  ---\n" +
+                "    detailid1: detail7\n" +
+                "    detailid2: detail8\n" +
+                "  ...\n" +
+                "ok 8 -" + testIds[7] + "\n" +
+                "    detailid1: incorrect\n" +
+                "    detailid2: incorrect\n" +
+                "\" > " + tapFileName + "\n");
+    }
+
+    public static void checkInteractiveJs(HtmlPage page) {
+        List scripts = page.getByXPath("//script");
+        assertTrue("At least one script must be there", scripts.size() > 0);
+        for (Object futureScript : scripts) {
+            HtmlScript scrip = (HtmlScript) futureScript;
+            if (scrip.getSrcAttribute().endsWith("/plugin/tap/interactive.js")) {
+                return;
+            }
+        }
+        throw new AssertionError("No ineractive.js found");
+    }
+
+    @Test
+    /**
+     * This tests checks that there is no JS exception if tap fie contains no tests
+     */
+    public void checkNoTestDoNotFault() throws IOException, SAXException, ExecutionException, InterruptedException {
+        final FreeStyleProject project = statJRule.createFreeStyleProject();
+        String tapFileName = "suite1.tap";
+        final Shell shell = new Shell("echo \"\" > " + tapFileName + "\n");
+        project.getBuildersList().add(shell);
+
+        final TapPublisher tapPublisher = getSimpleTapPublisher();
+        project.getPublishersList().add(tapPublisher);
+        project.save();
+
+        try (final JenkinsRule.WebClient wc = statJRule.createWebClient()) {
+            wc.setThrowExceptionOnFailingStatusCode(false);
+            Future<?> f = project.scheduleBuild2(0);
+            Run<?, ?> build = (Run<?, ?>) f.get();
+            HtmlPage page = wc.goTo("job/" + project.getName() + "/" + build.getNumber() + "/tapResults/");
+            checkInteractiveJs(page);
+            List tables = page.getByXPath("//table[@class='tap']");
+            assertEquals("There should still be tap table", 1, tables.size());
+            List centerCells = page.getByXPath("//td[@class='center']");
+            assertEquals("There should no test loaded", 0, centerCells.size());
+        }
+    }
+
+
+    @Test
+    @Issue("73484")
+    /**
+     * This tests feature where each test id is pointable by UNIQUE anchor and the acnhor is provided by it
+     */
+    public void checkLinkToTestExists() throws IOException, SAXException, ExecutionException, InterruptedException {
+        final FreeStyleProject project = statJRule.createFreeStyleProject();
+        String tapFileName = "suite1.tap";
+        String[] testIds = {
+                "Input file opened",
+                " First line of the input valid.",
+                "Read the rest of the file",
+                "Summarized correctly ",//this trailing space is important, it propagates to id
+
+        };
+        final Shell shell = new Shell("echo \"1..4\n" +
+                "ok 1 - " + testIds[0] + "\n" +
+                "not ok 2 - " + testIds[1] + "\n" +
+                "    More output from test 2. There can be\n" +
+                "    arbitrary number of lines for any output\n" +
+                "    so long as there is at least some kind\n" +
+                "    of whitespace at beginning of line.\n" +
+                "ok 3 - " + testIds[2] + "\n" +
+                "#TAP meta information\n" +
+                "not ok 4 - " + testIds[3] + "# TODO: not written yet" +
+                "\" > " + tapFileName + "\n");
+        project.getBuildersList().add(shell);
+        final TapPublisher tapPublisher = getSimpleTapPublisher();
+        project.getPublishersList().add(tapPublisher);
+        project.save();
+
+        try (final JenkinsRule.WebClient wc = statJRule.createWebClient()) {
+            wc.setThrowExceptionOnFailingStatusCode(false);
+            Future<?> f = project.scheduleBuild2(0);
+            Run<?, ?> build = (Run<?, ?>) f.get();
+            HtmlPage page = wc.goTo("job/" + project.getName() + "/" + build.getNumber() + "/tapResults/");
+            checkInteractiveJs(page);
+            List centerCells = page.getByXPath("//td[@class='center']");
+            assertEquals("There should be four tests loaded", 4, centerCells.size());
+            for (int x = 0; x < 4; x++) {
+                HtmlTableDataCell cell = (HtmlTableDataCell) centerCells.get(x);
+                DomNode anchorImpl = cell.getFirstChild();
+                HtmlAnchor anchor = (HtmlAnchor) anchorImpl;
+                String s = anchor.asXml();
+                String selfHref = anchor.getAttribute("name");
+                String href = anchor.getAttribute("href");
+                String text = anchor.getVisibleText();
+                assertEquals("the text should be order of result", "" + (x + 1), text);
+                assertEquals("the id and self point to it shoudl be same ", href, "#" + selfHref);
+                assertTrue("href must contain suite", href.contains(tapFileName));
+                assertTrue("href must contain id", href.contains("_" + (x + 1) + "_"));
+                assertTrue("href must contain test id", href.contains(testIds[x].replace(" ", "_")));
+                assertEquals("href should match following convention", ("#" + tapFileName + "_" + (x + 1) + "_-_" + testIds[x].replace(" ", "_") + "!").replaceAll("_+", "_"), href);
+            }
+        }
+    }
+
+    @Test
+    @Issue("73483")
+    /**
+     * this test checks that all is ivisble at start and that all classes needed forshow/hide actions are there
+     */
+    public void checkControlIdsExists() throws IOException, SAXException, ExecutionException, InterruptedException {
+        final FreeStyleProject project = statJRule.createFreeStyleProject();
+        String tapFileName = "suite2.tap";
+        project.getBuildersList().add(getShell(tapFileName));
+        final TapPublisher tapPublisher = getSimpleTapPublisher();
+        project.getPublishersList().add(tapPublisher);
+        project.save();
+
+        try (final JenkinsRule.WebClient wc = statJRule.createWebClient()) {
+            wc.setThrowExceptionOnFailingStatusCode(false);
+            Future<?> f = project.scheduleBuild2(0);
+            Run<?, ?> build = (Run<?, ?>) f.get();
+            HtmlPage page = wc.goTo("job/" + project.getName() + "/" + build.getNumber() + "/tapResults/");
+            String s1 = page.asXml();
+            checkInteractiveJs(page);
+            List tapMainRows = page.getByXPath("//table[@class='tap']/tbody/tr"); //there are also nested rows
+            //19=1header+3coments on top+1comment in middle+8tests 2bailedout lines + 4 comment rows (each detail is subrow in subtable)
+            int totalRows = 1 + 3 + 1 + 8 + 2 + 4;
+            assertEquals("There should be four tests loaded", totalRows, tapMainRows.size());
+            DomNode cellHead = (DomNode) tapMainRows.get(0);
+            assertEquals("header have no atts", 0, cellHead.getAttributes().getLength());
+            for (int x = 1; x < totalRows; x++) {
+                DomNode row = (DomNode) tapMainRows.get(x);
+                String s2 = row.asXml();
+                Node jsclazz = row.getAttributes().getNamedItem("class");
+                String jsClazzValue = jsclazz.getTextContent();
+                assertEquals("class at row " + x, classes[x], jsClazzValue);
+                HtmlTableRow tableRow = (HtmlTableRow) row;
+                assertTrue("the element must be visible", tableRow.isDisplayed());
+            }
+            List detailsRows = page.getByXPath("//table[@class='tap']/tbody/tr//tr");
+            //4 rows have valid detail. Each have 2 details. Each
+            assertEquals("There should be four tests loaded", 8, detailsRows.size());
+            for (int x = 0; x < detailsRows.size(); x++) {
+                int idCounter = (x % 2) + 1;
+                HtmlTableRow tableRow = (HtmlTableRow) (detailsRows.get(x));
+                HtmlTableCell nameCell1 = tableRow.getCell(1);
+                assertEquals("detailid" + idCounter + " +/-", nameCell1.getTextContent());
+                HtmlTableCell nameCell2 = tableRow.getCell(2);
+                String nameCelid2 = nameCell2.getAttribute("id");
+                String nameCellClazz2 = nameCell2.getAttribute("class");
+                assertEquals("detail_body", nameCellClazz2);
+                assertEquals("detail" + (x + 1), nameCell2.getTextContent());
+            }
+        }
+    }
+
+    @Test
+    @Issue("73483")
+    /**
+     * this test is chekcing that all ids in generated file are indeed unique
+     */
+    public void testUniqueIds() throws IOException, SAXException, ExecutionException, InterruptedException {
+        final FreeStyleProject project = statJRule.createFreeStyleProject();
+        String tapFileName = "suite2.tap";
+        project.getBuildersList().add(getShell(tapFileName));
+        final TapPublisher tapPublisher = getSimpleTapPublisher();
+        project.getPublishersList().add(tapPublisher);
+        project.save();
+        List<String> allIds = new ArrayList<>();
+        try (final JenkinsRule.WebClient wc = statJRule.createWebClient()) {
+            wc.setThrowExceptionOnFailingStatusCode(false);
+            Future<?> f = project.scheduleBuild2(0);
+            Run<?, ?> build = (Run<?, ?>) f.get();
+            HtmlPage page = wc.goTo("job/" + project.getName() + "/" + build.getNumber() + "/tapResults/");
+            String s1 = page.asXml();
+            checkInteractiveJs(page);
+            List tapMainRows = page.getByXPath("//table[@class='tap']/tbody/tr"); //there are also nested rows
+            int totalRows = 19;
+            assertEquals("There should be four tests loaded", totalRows, tapMainRows.size());
+            DomNode cellHead = (DomNode) tapMainRows.get(0);
+            assertEquals("header have no atts", 0, cellHead.getAttributes().getLength());
+            for (int x = 1; x < totalRows; x++) {
+                DomNode row = (DomNode) tapMainRows.get(x);
+                Node jsId = row.getAttributes().getNamedItem("id");
+                if (jsId != null) {
+                    String jsIdValue = jsId.getTextContent();
+                    allIds.add(jsIdValue);
+                }
+            }
+            List detailsRows = page.getByXPath("//table[@class='tap']/tbody/tr//tr");
+            //4 rows have valid detail. Each have 2 details. Each
+            assertEquals("There should be four tests loaded", 8, detailsRows.size());
+            for (int x = 0; x < detailsRows.size(); x++) {
+                HtmlTableRow tableRow = (HtmlTableRow) (detailsRows.get(x));
+                String rowId = tableRow.getId();
+                allIds.add(rowId);
+                HtmlTableCell nameCell2 = tableRow.getCell(2);
+                String nameCelid2 = nameCell2.getAttribute("id");
+                allIds.add(nameCelid2);
+            }
+            allIds = allIds.stream().filter(a -> {
+                return !a.isEmpty();
+            }).collect(Collectors.toList());
+            Set uniqueIds = new HashSet(allIds);
+            assertEquals("all ids must be unique", allIds.size(), uniqueIds.size());
+            List allPlusMinus = page.getByXPath("//u[@class='jsPM']");
+            List allNamedHrefs = page.getByXPath("//td/a[@name]");
+            List<String> unusedIds = new ArrayList<>(allIds);
+            List pmUnmatched = new ArrayList(allPlusMinus);
+            List pmMatched = new ArrayList();
+            List namedHrefsUnmatched = new ArrayList(allNamedHrefs);
+            List namedHrefsMatched = new ArrayList();
+            for (String id : allIds) {
+                for (Object pm : allPlusMinus) {
+                    HtmlElement ujp = (HtmlElement) pm;
+                    String clickM = ujp.getOnClickAttribute();
+                    String parameter = clickM.replaceAll(".*\\(\"", "").replaceAll("\"\\).*", "");
+                    if (parameter.equals(id)) {
+                        pmUnmatched.remove(pm);
+                        pmMatched.add(pm);
+                        unusedIds.remove(id);
+                    }
+                }
+                for (Object pm : allNamedHrefs) {
+                    HtmlElement ujp = (HtmlElement) pm;
+                    StringBuilder name = new StringBuilder(ujp.getAttribute("name"));
+                    String nwname = new StringBuilder(
+                            name.reverse().toString().replaceFirst("!", "")
+                    ).reverse().toString();
+                    if (nwname.equals(id)) {
+                        namedHrefsUnmatched.remove(pm);
+                        namedHrefsMatched.add(pm);
+                        unusedIds.remove(id);
+                    }
+                }
+            }
+            assertEquals("all ids were used", 0, unusedIds.size());
+            assertEquals("all hrefs were used", 0, namedHrefsUnmatched.size());
+            /*there are four rows without details, so thiers +/- shows nothing*/
+            assertEquals("all +/- with rows were used", 4, pmUnmatched.size());
+        }
+    }
+}


### PR DESCRIPTION
- possibility to hide/show
   - passed/failed/ignored/bailed out tests
   - diagnostic details
   - individual diagnostic items
   -  the three state buttons can control individual items
   - several preset views to mimic the major workflows
- number is now direct url to itself

precautions against CVE 3190 should be applied
tested in firefox and chromium


rebased https://github.com/jenkinsci/tap-plugin/pull/29
