### PR TITLE
[JENKINS-72561] Fix sidepanel.jelly not being loaded when build/project is not available (plug-ins, folders, etc.)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ test-output/
 .project
 **/*~
 .idea
+*.iml

--- a/src/main/java/org/tap4j/plugin/TapResult.java
+++ b/src/main/java/org/tap4j/plugin/TapResult.java
@@ -30,6 +30,9 @@ import hudson.tasks.test.TestObject;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang.StringUtils;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.export.Exported;
@@ -47,6 +50,7 @@ import org.tap4j.plugin.util.Constants;
 import org.tap4j.plugin.util.DiagnosticUtil;
 import org.tap4j.plugin.util.Util;
 
+import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import javax.servlet.ServletOutputStream;
 import java.io.File;
@@ -238,6 +242,16 @@ public class TapResult implements ModelObject, Serializable {
      */
     public void setOwner(Run<?, ?> owner) {
         this.build = owner;
+    }
+
+    @Restricted(NoExternalUse.class) // only used from stapler/jelly
+    @CheckForNull
+    public Run<?,?> getOwningRun() {
+        StaplerRequest req = Stapler.getCurrentRequest();
+        if (req == null) {
+            return null;
+        }
+        return req.findAncestorObject(Run.class);
     }
 
     public List<TestSetMap> getTestSets() {

--- a/src/main/java/org/tap4j/plugin/TapTestResultAction.java
+++ b/src/main/java/org/tap4j/plugin/TapTestResultAction.java
@@ -30,7 +30,6 @@ import hudson.model.HealthReport;
 import hudson.model.HealthReportingAction;
 import hudson.model.Job;
 import hudson.model.Run;
-import hudson.tasks.junit.CaseResult;
 import jenkins.model.RunAction2;
 import jenkins.tasks.SimpleBuildStep;
 import jenkins.util.NonLocalizable;
@@ -40,7 +39,6 @@ import org.tap4j.plugin.model.TapStreamResult;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 
 
 /**
@@ -90,13 +88,6 @@ public class TapTestResultAction
     @Exported(visibility = 2)
     public int getSkipCount() {
         return tapResult.getSkipped();
-    }
-
-    /* (non-Javadoc)
-     * @see hudson.tasks.test.AbstractTestResultAction#getFailedTests()
-     */
-    public List<CaseResult> getFailedTests() {
-        return Collections.emptyList();
     }
 
     /*

--- a/src/main/resources/org/tap4j/plugin/TapProjectAction/floatingBox.jelly
+++ b/src/main/resources/org/tap4j/plugin/TapProjectAction/floatingBox.jelly
@@ -1,5 +1,5 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:local="local">
+<j:jelly xmlns:j="jelly:core">
     <j:if test="${from.graphActive}">
       <div class="test-trend-caption">
          ${from.graphName}

--- a/src/main/resources/org/tap4j/plugin/TapProjectAction/nodata.jelly
+++ b/src/main/resources/org/tap4j/plugin/TapProjectAction/nodata.jelly
@@ -1,9 +1,10 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler"
-    xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
-    xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-    <l:layout>
-        <st:include it="${it.project}" page="sidepanel.jelly"/>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
+    <l:layout title="">
+        <j:set var="project" value="${it.project}" />
+        <j:if test="${project != null}">
+            <st:include it="${project}" page="sidepanel.jelly" optional="true" />
+        </j:if>
         <l:main-panel>
              <h1>${%header}</h1>
              <h2>${%description}</h2>

--- a/src/main/resources/org/tap4j/plugin/TapResult/contents.jelly
+++ b/src/main/resources/org/tap4j/plugin/TapResult/contents.jelly
@@ -1,12 +1,4 @@
 <?jelly escape-by-default='true'?>
-<j:jelly
-    xmlns:j="jelly:core" 
-    xmlns:st="jelly:stapler"
-    xmlns:d="jelly:define" 
-    xmlns:l="/lib/layout" 
-    xmlns:t="/lib/hudson"
-    xmlns:f="/lib/form" 
-    xmlns:i="jelly:fmt" 
-    xmlns:tap="/org/tap4j/plugin/tags">
+<j:jelly xmlns:j="jelly:core">
 <pre>${it.getContents(request.getParameter("f"))}</pre>
 </j:jelly>

--- a/src/main/resources/org/tap4j/plugin/TapResult/index.jelly
+++ b/src/main/resources/org/tap4j/plugin/TapResult/index.jelly
@@ -2,84 +2,87 @@
 <j:jelly
     xmlns:j="jelly:core" 
     xmlns:st="jelly:stapler"
-	xmlns:d="jelly:define" 
-	xmlns:l="/lib/layout" 
-	xmlns:t="/lib/hudson"
-	xmlns:f="/lib/form" 
-	xmlns:i="jelly:fmt" 
+	xmlns:l="/lib/layout"
 	xmlns:tap="/org/tap4j/plugin/tags">
-	<l:layout norefresh="true" css="/plugin/tap/css/tap.css">
-		<st:include it="${it.owner}" page="sidepanel.jelly" />
-		<l:main-panel>
-			
-			<h1>TAP Extended Test Results</h1>
-			
-			<j:choose>
-				<j:when test="${it.isEmptyTestSet()}">
-					<p>Empty test set</p>
-				</j:when>
-				<j:otherwise>
-				    ${it.updateStats()}
-				    <table width='100%'>
-				        <tr>
-				            <td width='5%'>${it.testSets.size()} files</td>
-				            <td>${it.getTotal()} tests, ${it.passed} ok, ${it.failed} not ok, ${it.skipped} skipped, ${it.toDo} ToDo, ${it.bailOuts} Bail Out!</td>
-				        </tr>
-				    </table>
-				    
-				    <j:if test="${it.showOnlyFailures}">
-				    	<p><strong>Note:</strong> Displaying only failures</p>
-				    </j:if>
+	<l:layout title="TAP Extended Test Results" norefresh="true">
+		<l:header>
+			<link rel="stylesheet" href="${rootURL}/plugin/tap/css/tap.css" />
+		</l:header>
+	    <j:set var="build" value="${it.owningRun}" />
+	    <j:if test="${build != null}">
+		    <st:include it="${build}" page="sidepanel.jelly" optional="true" />
 
-					<j:forEach var="map" items="${it.testSets}">
-					   <j:choose>
-					     <j:when test="${map.getTestSet().getPlan().isSkip()}">
-						   <p>File: <span class="underline"><a href='${rootURL}/${it.owner.url}artifact/${map.fileName}/*view*/'>${map.fileName}</a></span> (Skipped)</p>
-						 </j:when>
-						 <j:otherwise>
-					       <p>File: <span class="underline"><a href='${rootURL}/${it.owner.url}artifact/${map.fileName}/*view*/'>${map.fileName}</a></span></p>
-						 </j:otherwise>
-					   </j:choose>
-						 <table class="tap" width="100%">
+			<l:main-panel>
+
+				<h1>TAP Extended Test Results</h1>
+
+				<j:choose>
+					<j:when test="${it.isEmptyTestSet()}">
+						<p>Empty test set</p>
+					</j:when>
+					<j:otherwise>
+						${it.updateStats()}
+						<table width='100%'>
 							<tr>
-								<th> </th>
-								<th>Number</th>
-								<th>Description</th>
-								<th>Directive</th>
+								<td width='5%'>${it.testSets.size()} files</td>
+								<td>${it.getTotal()} tests, ${it.passed} ok, ${it.failed} not ok, ${it.skipped} skipped, ${it.toDo} ToDo, ${it.bailOuts} Bail Out!</td>
 							</tr>
-							<j:forEach var="tapLine" items="${map.testSet.tapLines}">
-								<!-- TAP Test Result information -->
-								<tap:line tapLine="${tapLine}" tapFile="${map.fileName}" showOnlyFailures="${it.showOnlyFailures}" />
-							</j:forEach>
 						</table>
-						<br />
-					</j:forEach>
 
-				</j:otherwise>
-			</j:choose>
-			
-			<h3><a name="parseErrors">Parse errors</a></h3>
-			
-			<j:choose>
-                <j:when test="${it.hasParseErrors() == false}">
-                    <p>No parse errors found</p>
-                </j:when>
-                <j:otherwise>
-                    <table class="tap" width="100%">
-                        <tr>
-                            <th>File name</th>
-                            <th>Cause</th>
-                        </tr>
-                        <j:forEach var="map" items="${it.parseErrorTestSets}">
-                        <tr>
-                            <td><a href='${rootURL}/${it.owner.url}artifact/${map.fileName}/*view*/'>${map.fileName}</a></td>
-                            <td>${map.cause}</td>
-                        </tr>
-                        </j:forEach>
-                     </table>
-                </j:otherwise>
-            </j:choose>
-            
-		</l:main-panel>
+						<j:if test="${it.showOnlyFailures}">
+							<p><strong>Note:</strong> Displaying only failures</p>
+						</j:if>
+
+						<j:forEach var="map" items="${it.testSets}">
+						   <j:choose>
+							 <j:when test="${map.getTestSet().getPlan().isSkip()}">
+							   <p>File: <span class="underline"><a href='${rootURL}/${build.url}artifact/${map.fileName}/*view*/'>${map.fileName}</a></span> (Skipped)</p>
+							 </j:when>
+							 <j:otherwise>
+							   <p>File: <span class="underline"><a href='${rootURL}/${build.url}artifact/${map.fileName}/*view*/'>${map.fileName}</a></span></p>
+							 </j:otherwise>
+						   </j:choose>
+							 <table class="tap" width="100%">
+								<tr>
+									<th> </th>
+									<th>Number</th>
+									<th>Description</th>
+									<th>Directive</th>
+								</tr>
+								<j:forEach var="tapLine" items="${map.testSet.tapLines}">
+									<!-- TAP Test Result information -->
+									<tap:line tapLine="${tapLine}" tapFile="${map.fileName}" showOnlyFailures="${it.showOnlyFailures}" />
+								</j:forEach>
+							</table>
+							<br />
+						</j:forEach>
+
+					</j:otherwise>
+				</j:choose>
+
+				<h3><a name="parseErrors">Parse errors</a></h3>
+
+				<j:choose>
+					<j:when test="${it.hasParseErrors() == false}">
+						<p>No parse errors found</p>
+					</j:when>
+					<j:otherwise>
+						<table class="tap" width="100%">
+							<tr>
+								<th>File name</th>
+								<th>Cause</th>
+							</tr>
+							<j:forEach var="map" items="${it.parseErrorTestSets}">
+							<tr>
+								<td><a href='${rootURL}/${build.url}artifact/${map.fileName}/*view*/'>${map.fileName}</a></td>
+								<td>${map.cause}</td>
+							</tr>
+							</j:forEach>
+						 </table>
+					</j:otherwise>
+				</j:choose>
+
+			</l:main-panel>
+		</j:if>
 	</l:layout>
 </j:jelly>


### PR DESCRIPTION
Implements suggestion from Victor (https://issues.jenkins.io/browse/JENKINS-72561), to be more defensive on loading sidepanel.jelly.

Pending some manual tests to confirm everything is working fine after this change.


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
