### PR TITLE
Fix showOnlyFailures for merged results

### DIFF
--- a/src/main/java/org/tap4j/plugin/TapResult.java
+++ b/src/main/java/org/tap4j/plugin/TapResult.java
@@ -105,8 +105,11 @@ public class TapResult implements ModelObject, Serializable {
         List<TestSetMap> mergedTestSets = new ArrayList<>(getTestSets());
         mergedTestSets.addAll(testSets);
 
-        return new TapResult(this.getName(), this.getOwner(), mergedTestSets, this.getTodoIsFailure(),
-                this.getIncludeCommentDiagnostics(), this.getValidateNumberOfTests());
+        TapResult tapResult = new TapResult(this.getName(), this.getOwner(), mergedTestSets, this.getTodoIsFailure(),
+            this.getIncludeCommentDiagnostics(), this.getValidateNumberOfTests());
+
+        tapResult.setShowOnlyFailures(getShowOnlyFailures());
+        return tapResult;
     }
 
     public Boolean getShowOnlyFailures() {

--- a/src/test/java/org/tap4j/plugin/PublisherKeepsPropertiesTest.java
+++ b/src/test/java/org/tap4j/plugin/PublisherKeepsPropertiesTest.java
@@ -1,0 +1,97 @@
+/*
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.tap4j.plugin;
+
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestBuilder;
+import org.jvnet.hudson.test.TouchBuilder;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertTrue;
+
+
+public class PublisherKeepsPropertiesTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+    private FreeStyleProject project;
+
+    @Before
+    public void setUp() throws Exception {
+        project = j.createFreeStyleProject("tap");
+
+        final String tap = "1..2\n" +
+                "ok 1 sample First ok\n" +
+                "not ok 2 sample Second failed\n";
+
+        project.getBuildersList().add(new TestBuilder() {
+            @Override
+            public boolean perform(AbstractBuild<?, ?> build, Launcher arg1,
+                    BuildListener arg2) throws InterruptedException, IOException {
+                build.getWorkspace().child("sample.tap").write(tap,"UTF-8");
+                return true;
+            }
+        });
+
+        project.getBuildersList().add(new TouchBuilder());
+    }
+
+    @Test
+    public void showOnlyFailures() throws Exception {
+        project.getPublishersList().add(sampleTapPublisher(true));
+        project.getPublishersList().add(sampleTapPublisher(true));
+        FreeStyleBuild build = project.scheduleBuild2(0).get(1000, TimeUnit.SECONDS);
+        TapTestResultAction testResultAction = build.getAction(TapTestResultAction.class);
+        assertTrue(testResultAction.getTapResult().getShowOnlyFailures());
+    }
+
+    TapPublisher sampleTapPublisher(boolean showOnlyFailures) {
+        return new TapPublisher(
+                "sample.tap",
+                true,
+                true,
+                false,
+                true,
+                true,
+                false,
+                true,
+                true,
+                true,
+                false,
+                showOnlyFailures,
+                false,
+                false,
+                false,
+                false
+        );
+    }
+}


### PR DESCRIPTION
Fixes https://issues.jenkins.io/browse/JENKINS-75332

### Testing done

Manually verified in the "TAP Extended Test Results" that the Testpipeline respects `showOnlyFailures`
```
pipeline {
    agent any
    stages {
        stage('Build') {
            steps {
                writeFile file: 'test1.tap', text: 'ok 1\nnot ok 2'
                writeFile file: 'test2.tap', text: 'ok 1\nnot ok 2'
            }
            post {
                always {
                    step $class: 'TapPublisher', testResults: 'test1.tap', showOnlyFailures: true, planRequired: false
                    step $class: 'TapPublisher', testResults: 'test2.tap', showOnlyFailures: true, planRequired: false
                }
            }
        }
    }
}
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
