### PR TITLE
[JENKINS-76360] Fix NPE on TAP Test Results screen

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 - build(deps): bump org.yaml:snakeyaml from 2.2 to 2.6
 - [GH-44](https://github.com/jenkinsci/tap-plugin/pull/44): Add @Symbol("publishTap") to TapPublisher Descriptor and pipeline test (thanks @0xShubhamSolanki)
+- [JENKINS-76360](https://issues.jenkins.io/browse/JENKINS-76360) Fix NPE on TAP Test Results screen (thanks @janfaracik)
 
 ## Version 2.4.4 (2025/03/13)
 

--- a/src/main/java/org/tap4j/plugin/TapTestResultAction.java
+++ b/src/main/java/org/tap4j/plugin/TapTestResultAction.java
@@ -30,6 +30,7 @@ import hudson.model.HealthReport;
 import hudson.model.HealthReportingAction;
 import hudson.model.Job;
 import hudson.model.Run;
+import hudson.tasks.test.AbstractTestResultAction;
 import jenkins.model.RunAction2;
 import jenkins.tasks.SimpleBuildStep;
 import jenkins.util.NonLocalizable;
@@ -44,12 +45,8 @@ import java.util.Collections;
 /**
  * @since 0.1
  */
-public class TapTestResultAction
+public class TapTestResultAction extends AbstractTestResultAction<TapTestResultAction>
         implements StaplerProxy, SimpleBuildStep.LastBuildAction, HealthReportingAction, RunAction2 {
-
-    public transient Run<?, ?> run;
-    @Deprecated
-    public transient AbstractBuild<?, ?> owner;
 
     private TapResult tapResult;
 
@@ -57,6 +54,13 @@ public class TapTestResultAction
         setRunAndOwner(r);
 
         this.tapResult = tapResult;
+    }
+
+    /**
+     * @return the current Run to support new JUnit
+     */
+    public Run<?, ?> getObject() {
+        return run;
     }
 
     /**
@@ -99,7 +103,7 @@ public class TapTestResultAction
     }
 
     public TapStreamResult getResult() {
-        return new TapStreamResult(owner, tapResult);
+        return new TapStreamResult(owner, tapResult, this);
     }
 
     /* (non-Javadoc)

--- a/src/main/java/org/tap4j/plugin/model/TapStreamResult.java
+++ b/src/main/java/org/tap4j/plugin/model/TapStreamResult.java
@@ -25,6 +25,7 @@ package org.tap4j.plugin.model;
 
 import hudson.model.Run;
 import hudson.tasks.junit.CaseResult;
+import hudson.tasks.test.AbstractTestResultAction;
 import hudson.tasks.test.TabulatedResult;
 import hudson.tasks.test.TestObject;
 import hudson.tasks.test.TestResult;
@@ -33,6 +34,7 @@ import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.export.Exported;
 import org.tap4j.model.TestSet;
 import org.tap4j.plugin.TapResult;
+import org.tap4j.plugin.TapTestResultAction;
 import org.tap4j.util.StatusValues;
 
 import javax.annotation.Nullable;
@@ -50,12 +52,14 @@ public class TapStreamResult extends TabulatedResult {
 
     private static final long serialVersionUID = 8337146933697574082L;
     private final transient Run<?, ?> owner;
+    private final transient AbstractTestResultAction tapTestResultAction;
     private List<TestResult> children = new ArrayList<>();
     private TapResult tapResult;
 
-    public TapStreamResult(Run<?, ?> owner, TapResult tapResult) {
+    public TapStreamResult(Run<?, ?> owner, TapResult tapResult, AbstractTestResultAction tapTestResultAction) {
         this.owner = owner;
         this.tapResult = tapResult;
+        this.tapTestResultAction = tapTestResultAction;
         setChildrenInfo();
     }
     
@@ -73,6 +77,15 @@ public class TapStreamResult extends TabulatedResult {
     @Override
     public Run<?, ?> getRun() {
         return owner;
+    }
+
+    public String getTitle() {
+        return getDisplayName();
+    }
+
+    @Override
+    public AbstractTestResultAction getParentAction() {
+        return tapTestResultAction;
     }
 
     /* (non-Javadoc)

--- a/src/main/java/org/tap4j/plugin/model/TapStreamResult.java
+++ b/src/main/java/org/tap4j/plugin/model/TapStreamResult.java
@@ -52,6 +52,11 @@ public class TapStreamResult extends TabulatedResult {
 
     private static final long serialVersionUID = 8337146933697574082L;
     private final transient Run<?, ?> owner;
+    /**
+     * The owning action is required by newer Jenkins test result rendering.
+     * TapStreamResult instances are recreated by TapTestResultAction#getResult(),
+     * so this reference does not need to be persisted.
+     */
     private final transient AbstractTestResultAction tapTestResultAction;
     private List<TestResult> children = new ArrayList<>();
     private TapResult tapResult;

--- a/src/main/java/org/tap4j/plugin/model/TapTestResultResult.java
+++ b/src/main/java/org/tap4j/plugin/model/TapTestResultResult.java
@@ -106,7 +106,7 @@ public class TapTestResultResult extends TestResult {
             TestSetMap subTest = new TestSetMap(testSetMap.getFileName(), testSet);
             List<TestSetMap> list = new ArrayList<>();
             list.add(subTest);
-            parent = new TapStreamResult(owner, new TapResult("TAP Test Results", owner, list, todoIsFailure, includeCommentDiagnostics, validateNumberOfTests));
+            parent = new TapStreamResult(owner, new TapResult("TAP Test Results", owner, list, todoIsFailure, includeCommentDiagnostics, validateNumberOfTests), getTestResultAction());
         }
         return parent;
     }

--- a/src/test/java/org/tap4j/plugin/TapPublisherTest.java
+++ b/src/test/java/org/tap4j/plugin/TapPublisherTest.java
@@ -32,6 +32,7 @@ import hudson.tasks.test.TestResult;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TouchBuilder;
 import org.jvnet.hudson.test.recipes.LocalData;
@@ -43,6 +44,8 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 
 public class TapPublisherTest {
@@ -97,6 +100,9 @@ public class TapPublisherTest {
         project.getBuildersList().add(new TouchBuilder());
     }
 
+    /**
+     * Verifies that TAP results are published and the TAP report pages are accessible.
+     */
     @LocalData
     @Test
     // getPage uses deprecation to tell users about a possibility to use relative pages (shrugs)
@@ -125,6 +131,9 @@ public class TapPublisherTest {
         }
     }
 
+    /**
+     * Verifies that multiple TAP publishers are merged into a single test result.
+     */
     @LocalData
     @Test
     // getPage uses deprecation to tell users about a possibility to use relative pages (shrugs)
@@ -199,6 +208,9 @@ public class TapPublisherTest {
         return result.getRelativePathFrom(testObject);
     }
 
+    /**
+     * Verifies that TAP results can be published when the build runs on an agent.
+     */
     @LocalData
     @Test
     public void slave() throws Exception {
@@ -237,8 +249,16 @@ public class TapPublisherTest {
 
         assertEquals(String.format("should have %d skipped test", 1), 1, testResultAction.getSkipCount());
         assertEquals(String.format("should have %d skipped test", 1), 1, result.getSkipCount());
+
+        assertTrue(result instanceof TapStreamResult);
+
+        TapStreamResult streamResult = (TapStreamResult) result;
+        assertSame("parent action should be the owning TapTestResultAction", testResultAction, streamResult.getParentAction());
     }
 
+    /**
+     * Verifies that TAP results remain available after Jenkins is reloaded.
+     */
     @LocalData
     @Test
     public void persistence() throws Exception {
@@ -256,10 +276,52 @@ public class TapPublisherTest {
         project = (FreeStyleProject) j.jenkins.getItem("tap");
     }
 
+
     @Test
     public void emptyDirectory() throws Exception {
         FreeStyleProject freeStyleProject = j.createFreeStyleProject();
         freeStyleProject.getPublishersList().add(archiver1);
         j.assertBuildStatus(Result.FAILURE, freeStyleProject.scheduleBuild2(0).get());
+    }
+
+    /**
+     * Verifies that the TAP report page renders after Jenkins reloads the build.
+     *
+     * <p>This covers the regression where the TAP test result page failed to render
+     * after changes in the Jenkins JUnit plugin.</p>
+     */
+    @LocalData
+    @Issue("JENKINS-76360")
+    @Test
+    public void testReportPageRendersAfterReload() throws Exception {
+        project.scheduleBuild2(0).get(1000, TimeUnit.SECONDS);
+
+        reloadJenkins();
+
+        FreeStyleBuild build = project.getBuildByNumber(1);
+
+        try (JenkinsRule.WebClient wc = j.new WebClient()) {
+            wc.getPage(build, "tapTestReport");
+        }
+    }
+
+    /**
+     * Verifies that the TAP result keeps its parent action after Jenkins reloads.
+     *
+     * <p>The parent action is required by Jenkins test result rendering.</p>
+     */
+    @LocalData
+    @Issue("JENKINS-76360")
+    @Test
+    public void persistenceKeepsParentAction() throws Exception {
+        project.scheduleBuild2(0).get(60, TimeUnit.SECONDS);
+
+        reloadJenkins();
+
+        FreeStyleBuild build = project.getBuildByNumber(1);
+        TapTestResultAction action = build.getAction(TapTestResultAction.class);
+
+        assertNotNull(action);
+        assertSame(action, action.getResult().getParentAction());
     }
 }

--- a/src/test/java/org/tap4j/plugin/TapPublisherTest.java
+++ b/src/test/java/org/tap4j/plugin/TapPublisherTest.java
@@ -45,9 +45,11 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
 
 
+/**
+ * Tests for the {@link TapPublisher}.
+ */
 public class TapPublisherTest {
 
     @Rule
@@ -238,21 +240,18 @@ public class TapPublisherTest {
         TapTestResultAction testResultAction = build.getAction(TapTestResultAction.class);
         assertNotNull("no TestResultAction", testResultAction);
 
-        TestResult result = testResultAction.getResult();
-        assertNotNull("no TestResult", result);
+        TapStreamResult streamResult = testResultAction.getResult();
+        assertNotNull("no TestResult", streamResult);
 
         assertEquals(String.format("should have %d failing test", failed), failed, testResultAction.getFailCount());
-        assertEquals(String.format("should have %d failing test", failed), failed, result.getFailCount());
+        assertEquals(String.format("should have %d failing test", failed), failed, streamResult.getFailCount());
 
         assertEquals(String.format("should have %d total tests", total), total, testResultAction.getTotalCount());
-        assertEquals(String.format("should have %d total tests", total), total, result.getTotalCount());
+        assertEquals(String.format("should have %d total tests", total), total, streamResult.getTotalCount());
 
         assertEquals(String.format("should have %d skipped test", 1), 1, testResultAction.getSkipCount());
-        assertEquals(String.format("should have %d skipped test", 1), 1, result.getSkipCount());
+        assertEquals(String.format("should have %d skipped test", 1), 1, streamResult.getSkipCount());
 
-        assertTrue(result instanceof TapStreamResult);
-
-        TapStreamResult streamResult = (TapStreamResult) result;
         assertSame("parent action should be the owning TapTestResultAction", testResultAction, streamResult.getParentAction());
     }
 


### PR DESCRIPTION
Would appreciate some insight from plugin maintainers here. I've fixed the null pointer issue, essentially caused by expected methods not existing in this plugin setup. The `getTarget` call made this a little more complicated to debug initially, so would appreciate a review.

### Testing done

* Screen appears, title shows, tests show

<img width="1728" height="618" alt="image" src="https://github.com/user-attachments/assets/2afc0af9-a570-461a-b276-4bcd173fda6d" />

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
