### PR TITLE
Add @Symbol("publishTap") to TapPublisher Descriptor and pipeline test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ test-output/
 **/*~
 .idea
 *.iml
+.vscode/
+

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "java.configuration.updateBuildConfiguration": "interactive"
-}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Version 2.4.5 (2025/??/??)
 
-- 
+- [GH-44](https://github.com/jenkinsci/tap-plugin/pull/44): Add @Symbol("publishTap") to TapPublisher Descriptor and pipeline test (thanks @0xShubhamSolanki)
 
 ## Version 2.4.4 (2025/03/13)
 

--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,11 @@ SOFTWARE.
       <artifactId>workflow-step-api</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-basic-steps</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,11 @@ SOFTWARE.
       <artifactId>workflow-cps</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-step-api</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/org/tap4j/plugin/TapPublisher.java
+++ b/src/main/java/org/tap4j/plugin/TapPublisher.java
@@ -40,6 +40,7 @@ import org.tap4j.model.Plan;
 import org.tap4j.model.TestSet;
 import org.tap4j.plugin.model.TestSetMap;
 import org.tap4j.plugin.util.Constants;
+import org.jenkinsci.Symbol;
 
 import hudson.EnvVars;
 import hudson.Extension;
@@ -582,6 +583,7 @@ public class TapPublisher extends Recorder implements MatrixAggregatable, Simple
     }
 
     @Extension
+    @Symbol("publishTap")
     public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {
         public DescriptorImpl() {
             super(TapPublisher.class);

--- a/src/test/java/org/tap4j/plugin/TapPublisherPipelineTest.java
+++ b/src/test/java/org/tap4j/plugin/TapPublisherPipelineTest.java
@@ -1,9 +1,30 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2010-2026 Bruno P. Kinoshita
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ */
 package org.tap4j.plugin;
 
+import hudson.model.Result;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 
 public class TapPublisherPipelineTest {
@@ -12,13 +33,23 @@ public class TapPublisherPipelineTest {
     public JenkinsRule j = new JenkinsRule();
 
     @Test
-    public void publishTapSymbolWorks() throws Exception {
+    public void publishTapSymbolWorksWithValidTapFile() throws Exception {
+
         WorkflowJob job = j.createProject(WorkflowJob.class);
 
         job.setDefinition(new CpsFlowDefinition(
-                "publishTap(testResults: 'test.log')",
-                true));
+            "node {\n" +
+            "  writeFile file: 'test.log', text: '1..1\\nok 1 - Sample test\\n'\n" +
+            "  publishTap(testResults: 'test.log')\n" +
+            "}",
+            true
+        ));
 
-        j.buildAndAssertSuccess(job);
+        WorkflowRun run = j.buildAndAssertSuccess(job);
+
+        j.assertBuildStatus(Result.SUCCESS, run);
+        j.assertLogContains("TAP Reports Processing: START", run);
+        j.assertLogContains("TAP Reports Processing: FINISH", run);
     }
 }
+

--- a/src/test/java/org/tap4j/plugin/TapPublisherPipelineTest.java
+++ b/src/test/java/org/tap4j/plugin/TapPublisherPipelineTest.java
@@ -1,0 +1,24 @@
+package org.tap4j.plugin;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+
+public class TapPublisherPipelineTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void publishTapSymbolWorks() throws Exception {
+        WorkflowJob job = j.createProject(WorkflowJob.class);
+
+        job.setDefinition(new CpsFlowDefinition(
+                "publishTap(testResults: 'test.log')",
+                true));
+
+        j.buildAndAssertSuccess(job);
+    }
+}


### PR DESCRIPTION
Fixes JENKINS-43785

## Description

This pull request adds the `@Symbol("publishTap")` annotation to the `TapPublisher` descriptor.
With this change, the step can now be used directly in Pipeline scripts as:

    publishTap(testResults: 'test.log')

Previously, the publisher did not expose a Pipeline symbol, which made its usage in Pipeline jobs less straightforward.
A small Pipeline test has also been added to confirm that the symbol is properly registered and works in a `WorkflowJob`.

## Testing done

- Ran `mvn clean verify` locally and confirmed all tests pass.
- Added a new `TapPublisherPipelineTest` to ensure the `publishTap` step works in a Pipeline job.
- Verified that the build completes successfully in the test environment.

This change does not modify existing behavior, only exposes the publisher through a Pipeline symbol and adds a corresponding test.