### PR TITLE
Updated depnendece versions to jenkins recomanded one

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @jenkinsci/tap-plugin-developers

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,7 @@
 // Build the plugin using https://github.com/jenkins-infra/pipeline-library
 buildPlugin(useContainerAgent: true, failFast: false, forkCount: '1C', configurations: [
-  [platform: 'linux', jdk: 17],
+  [platform: 'windows', jdk: 21],
+  [platform: 'windows', jdk: 25],
+  [platform: 'linux', jdk: 21],
+  [platform: 'linux', jdk: 25],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@ SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.76</version>
+    <version>6.2211.v27f680c93c53</version>
     <relativePath />
   </parent>
 
@@ -40,9 +40,9 @@ SOFTWARE.
   <version>2.4.5-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
-  <name>Jenkins TAP Plugin</name>
+  <name>TAP Plugin</name>
   <description>This plugin publishes TAP test results.</description>
-  <url>https://github.com/jenkinsci/tap-plugin</url>
+  <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
 
   <licenses>
     <license>
@@ -59,9 +59,15 @@ SOFTWARE.
   <properties>
     <revision>2.4.0</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.426.1</jenkins.version>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+    <jenkins.baseline>2.555</jenkins.baseline>
     <gitHubRepo>jenkinsci/tap-plugin</gitHubRepo>
     <tap4j.version>4.4.2</tap4j.version>
+    <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
+    <banObsoleteDependencyOverrides.skip>false</banObsoleteDependencyOverrides.skip>
+    <ban-deprecated-stapler.skip>false</ban-deprecated-stapler.skip>
+    <ban-commons-lang-2.skip>false</ban-commons-lang-2.skip>
+    <hpi.bundledArtifacts>tap4j</hpi.bundledArtifacts>
   </properties>
 
   <scm>
@@ -71,20 +77,12 @@ SOFTWARE.
     <tag>${scmTag}</tag>
   </scm>
 
-  <developers>
-    <developer>
-      <id>kinow</id>
-      <name>Bruno P. Kinoshita</name>
-      <timezone>Europe/Madrid</timezone>
-    </developer>
-  </developers>
-
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.426.x</artifactId>
-        <version>2598.v49e2b_e68d413</version>
+        <artifactId>bom-${jenkins.baseline}.x</artifactId>
+        <version>6751.v745d6a_31066a_</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -105,9 +103,8 @@ SOFTWARE.
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.yaml</groupId>
-      <artifactId>snakeyaml</artifactId>
-      <version>2.6</version>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>snakeyaml-api</artifactId>
     </dependency>
     <!-- For handling matrix jobs -->
     <dependency>
@@ -153,14 +150,6 @@ SOFTWARE.
           <compatibleSinceVersion>2.0</compatibleSinceVersion>
         </configuration>
       </plugin>
-        <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-                <source>15</source>
-                <target>15</target>
-            </configuration>
-        </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@ SOFTWARE.
     <ban-deprecated-stapler.skip>false</ban-deprecated-stapler.skip>
     <ban-commons-lang-2.skip>false</ban-commons-lang-2.skip>
     <hpi.bundledArtifacts>tap4j</hpi.bundledArtifacts>
+    <ban-junit4-imports.skip >false</ban-junit4-imports.skip >
   </properties>
 
   <scm>

--- a/src/main/java/org/tap4j/plugin/TapBuildAction.java
+++ b/src/main/java/org/tap4j/plugin/TapBuildAction.java
@@ -27,7 +27,7 @@ import hudson.model.Action;
 import hudson.model.Run;
 import org.kohsuke.stapler.StaplerProxy;
 
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.Serializable;
 
 /**

--- a/src/main/java/org/tap4j/plugin/TapProjectAction.java
+++ b/src/main/java/org/tap4j/plugin/TapProjectAction.java
@@ -29,10 +29,10 @@ import hudson.model.Job;
 import hudson.model.Run;
 import hudson.util.ChartUtil;
 import hudson.util.DataSetBuilder;
-import hudson.util.RunList;
 import org.jfree.chart.JFreeChart;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.StaplerResponse2;
+import org.kohsuke.stapler.interceptor.RequirePOST;
 import org.tap4j.plugin.util.GraphHelper;
 
 import java.io.IOException;
@@ -110,6 +110,8 @@ public class TapProjectAction extends AbstractTapProjectAction {
         return lastBuild;
     }
 
+    @RequirePOST
+    @SuppressWarnings("lgtm[jenkins/no-permission-check]")
     public void doIndex( final StaplerRequest2 request,
             final StaplerResponse2 response ) throws IOException {
         Run<?, ?> lastBuild = this.getLastBuildWithTap();
@@ -129,6 +131,8 @@ public class TapProjectAction extends AbstractTapProjectAction {
      * @param rsp Stapler response
      * @throws IOException if it fails to create the graph image and serve it
      */
+    @RequirePOST
+    @SuppressWarnings("lgtm[jenkins/no-permission-check]")
     public void doGraph( final StaplerRequest2 req, StaplerResponse2 rsp ) throws IOException {
         if (newGraphNotNeeded(req, rsp)) {
             return;
@@ -144,6 +148,8 @@ public class TapProjectAction extends AbstractTapProjectAction {
         }.doPng(req, rsp);
     }
 
+    @RequirePOST
+    @SuppressWarnings("lgtm[jenkins/no-permission-check]")
     public void doGraphMap( final StaplerRequest2 req, StaplerResponse2 rsp ) throws IOException {
         if (newGraphNotNeeded(req, rsp)) {
             return;

--- a/src/main/java/org/tap4j/plugin/TapProjectAction.java
+++ b/src/main/java/org/tap4j/plugin/TapProjectAction.java
@@ -31,8 +31,8 @@ import hudson.util.ChartUtil;
 import hudson.util.DataSetBuilder;
 import hudson.util.RunList;
 import org.jfree.chart.JFreeChart;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 import org.tap4j.plugin.util.GraphHelper;
 
 import java.io.IOException;
@@ -110,8 +110,8 @@ public class TapProjectAction extends AbstractTapProjectAction {
         return lastBuild;
     }
 
-    public void doIndex( final StaplerRequest request,
-            final StaplerResponse response ) throws IOException {
+    public void doIndex( final StaplerRequest2 request,
+            final StaplerResponse2 response ) throws IOException {
         Run<?, ?> lastBuild = this.getLastBuildWithTap();
         if (lastBuild == null) {
             response.sendRedirect2("nodata");
@@ -129,7 +129,7 @@ public class TapProjectAction extends AbstractTapProjectAction {
      * @param rsp Stapler response
      * @throws IOException if it fails to create the graph image and serve it
      */
-    public void doGraph( final StaplerRequest req, StaplerResponse rsp ) throws IOException {
+    public void doGraph( final StaplerRequest2 req, StaplerResponse2 rsp ) throws IOException {
         if (newGraphNotNeeded(req, rsp)) {
             return;
         }
@@ -144,7 +144,7 @@ public class TapProjectAction extends AbstractTapProjectAction {
         }.doPng(req, rsp);
     }
 
-    public void doGraphMap( final StaplerRequest req, StaplerResponse rsp ) throws IOException {
+    public void doGraphMap( final StaplerRequest2 req, StaplerResponse2 rsp ) throws IOException {
         if (newGraphNotNeeded(req, rsp)) {
             return;
         }
@@ -210,7 +210,7 @@ public class TapProjectAction extends AbstractTapProjectAction {
      * @param rsp Stapler response
      * @return true, if new image does NOT need to be generated, false otherwise
      */
-    private boolean newGraphNotNeeded( final StaplerRequest req, StaplerResponse rsp ) {
+    private boolean newGraphNotNeeded( final StaplerRequest2 req, StaplerResponse2 rsp ) {
         final Calendar t = this.job.getLastCompletedBuild().getTimestamp();
         final int prevNumBuilds = requestMap.getOrDefault(req.getRequestURI(), 0);
         final int numBuilds = (int) this.job.getBuilds().stream().count();

--- a/src/main/java/org/tap4j/plugin/TapPublisher.java
+++ b/src/main/java/org/tap4j/plugin/TapPublisher.java
@@ -31,10 +31,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
-import org.apache.commons.lang.BooleanUtils;
+import org.apache.commons.lang3.BooleanUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.tap4j.model.Plan;
 import org.tap4j.model.TestSet;
@@ -304,10 +304,10 @@ public class TapPublisher extends Recorder implements MatrixAggregatable, Simple
      */
     @Override
     public void perform(
-            @Nonnull Run<?, ?> run,
-            @Nonnull FilePath workspace,
-            @Nonnull Launcher launcher,
-            @Nonnull TaskListener listener)
+            @NonNull Run<?, ?> run,
+            @NonNull FilePath workspace,
+            @NonNull Launcher launcher,
+            @NonNull TaskListener listener)
             throws InterruptedException, IOException {
 
         performImpl(run, workspace, listener);
@@ -590,7 +590,7 @@ public class TapPublisher extends Recorder implements MatrixAggregatable, Simple
             load();
         }
 
-        @Nonnull
+        @NonNull
         @Override
         public String getDisplayName() {
             return "Publish TAP Results";

--- a/src/main/java/org/tap4j/plugin/TapResult.java
+++ b/src/main/java/org/tap4j/plugin/TapResult.java
@@ -28,13 +28,13 @@ import hudson.model.ModelObject;
 import hudson.model.Run;
 import hudson.tasks.test.TestObject;
 import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.lang.BooleanUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.Stapler;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.export.Exported;
 import org.tap4j.consumer.TapConsumer;
 import org.tap4j.consumer.TapConsumerFactory;
@@ -50,9 +50,9 @@ import org.tap4j.plugin.util.Constants;
 import org.tap4j.plugin.util.DiagnosticUtil;
 import org.tap4j.plugin.util.Util;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nullable;
-import javax.servlet.ServletOutputStream;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import jakarta.servlet.ServletOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
@@ -250,7 +250,7 @@ public class TapResult implements ModelObject, Serializable {
     @Restricted(NoExternalUse.class) // only used from stapler/jelly
     @CheckForNull
     public Run<?,?> getOwningRun() {
-        StaplerRequest req = Stapler.getCurrentRequest();
+        StaplerRequest2 req = Stapler.getCurrentRequest2();
         if (req == null) {
             return null;
         }
@@ -356,7 +356,7 @@ public class TapResult implements ModelObject, Serializable {
         return getName();
     }
 
-    public void doDownloadAttachment(StaplerRequest request, StaplerResponse response) {
+    public void doDownloadAttachment(StaplerRequest2 request, StaplerResponse2 response) {
         final String f = request.getParameter("f");
         final String key = request.getParameter("key");
         try {

--- a/src/main/java/org/tap4j/plugin/TapResult.java
+++ b/src/main/java/org/tap4j/plugin/TapResult.java
@@ -36,6 +36,7 @@ import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.interceptor.RequirePOST;
 import org.tap4j.consumer.TapConsumer;
 import org.tap4j.consumer.TapConsumerFactory;
 import org.tap4j.model.BailOut;
@@ -356,6 +357,8 @@ public class TapResult implements ModelObject, Serializable {
         return getName();
     }
 
+    @RequirePOST
+    @SuppressWarnings("lgtm[jenkins/no-permission-check]")
     public void doDownloadAttachment(StaplerRequest2 request, StaplerResponse2 response) {
         final String f = request.getParameter("f");
         final String key = request.getParameter("key");

--- a/src/main/java/org/tap4j/plugin/model/TapStreamResult.java
+++ b/src/main/java/org/tap4j/plugin/model/TapStreamResult.java
@@ -29,15 +29,15 @@ import hudson.tasks.test.AbstractTestResultAction;
 import hudson.tasks.test.TabulatedResult;
 import hudson.tasks.test.TestObject;
 import hudson.tasks.test.TestResult;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.export.Exported;
 import org.tap4j.model.TestSet;
 import org.tap4j.plugin.TapResult;
 import org.tap4j.plugin.TapTestResultAction;
 import org.tap4j.util.StatusValues;
 
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -186,7 +186,7 @@ public class TapStreamResult extends TabulatedResult {
     }
 
     @Override
-    public Object getDynamic(String name, StaplerRequest req, StaplerResponse rsp) {
+    public Object getDynamic(String name, StaplerRequest2 req, StaplerResponse2 rsp) {
         TapTestResultResult tr = getTapTestResultResult(name);
         if (tr != null) {
             return tr;

--- a/src/main/java/org/tap4j/plugin/model/TapTestResultResult.java
+++ b/src/main/java/org/tap4j/plugin/model/TapTestResultResult.java
@@ -30,9 +30,9 @@ import hudson.model.Run;
 import hudson.tasks.test.TestObject;
 import hudson.tasks.test.TestResult;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.stapler.Stapler;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 import org.tap4j.model.Comment;
 import org.tap4j.model.Directive;
 import org.tap4j.model.TestSet;
@@ -41,8 +41,8 @@ import org.tap4j.plugin.TapTestResultAction;
 import org.tap4j.plugin.util.Util;
 import org.tap4j.util.DirectiveValues;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -210,7 +210,7 @@ public class TapTestResultResult extends TestResult {
             buf.insert(0, myBuild.getUrl());
 
             // If we're inside a stapler request, just delegate to Hudson.Functions to get the relative path!
-            StaplerRequest req = Stapler.getCurrentRequest();
+            StaplerRequest2 req = Stapler.getCurrentRequest2();
             if (req != null && myBuild instanceof Item) {
                 buf.insert(0, '/');
                 // Ugly but I don't see how else to convince the compiler that myBuild is an Item

--- a/src/main/java/org/tap4j/plugin/util/DiagnosticUtil.java
+++ b/src/main/java/org/tap4j/plugin/util/DiagnosticUtil.java
@@ -24,7 +24,7 @@
 package org.tap4j.plugin.util;
 
 import hudson.Functions;
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang3.StringEscapeUtils;
 
 import java.util.Arrays;
 import java.util.List;
@@ -82,7 +82,7 @@ public class DiagnosticUtil {
             sb.append("<tr>");
 
             sb.append("<td width='5%' class='hidden'> </td>".repeat(Math.max(0, depth)));
-            sb.append("<td style=\"width: auto;\">").append(StringEscapeUtils.escapeHtml(key)).append("</td>");
+            sb.append("<td style=\"width: auto;\">").append(StringEscapeUtils.escapeHtml4(key)).append("</td>");
 
             if(renderType == RENDER_TYPE.IMAGE && key.equals("File-Content")) {
                 final Object o = diagnostic.get("File-Name");
@@ -95,14 +95,14 @@ public class DiagnosticUtil {
                         "&key=",
                         Functions.htmlAttributeEscape(downloadKey),
                         "'>",
-                        StringEscapeUtils.escapeHtml(fileName),
+                        StringEscapeUtils.escapeHtml4(fileName),
                         "</a></td>"
                 ).forEach(sb::append);
             } else if (renderType == RENDER_TYPE.TEXT && value instanceof java.util.Map) {
                 sb.append("<td> </td>");
                 createDiagnosticTableRecursively(tapFile, key, (java.util.Map) value, sb, (depth + 1));
             } else {
-                sb.append("<td><pre>").append(org.apache.commons.lang.StringEscapeUtils.escapeHtml(value.toString())).append("</pre></td>");
+                sb.append("<td><pre>").append(StringEscapeUtils.escapeHtml4(value.toString())).append("</pre></td>");
             }
             sb.append("</tr>");
         }

--- a/src/main/java/org/tap4j/plugin/util/GraphHelper.java
+++ b/src/main/java/org/tap4j/plugin/util/GraphHelper.java
@@ -40,8 +40,8 @@ import org.jfree.chart.title.LegendTitle;
 import org.jfree.data.category.CategoryDataset;
 import org.jfree.ui.RectangleEdge;
 import org.jfree.ui.RectangleInsets;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 import org.tap4j.plugin.AbstractTapProjectAction;
 import org.tap4j.plugin.TapBuildAction;
 import org.tap4j.plugin.TapResult;
@@ -68,14 +68,14 @@ public class GraphHelper
         super();
     }
 
-    public static void redirectWhenGraphUnsupported( StaplerResponse rsp,
-            StaplerRequest req ) throws IOException
+    public static void redirectWhenGraphUnsupported( StaplerResponse2 rsp,
+            StaplerRequest2 req ) throws IOException
     {
         // not available. send out error message
         rsp.sendRedirect2(req.getContextPath() + "/images/headless.png");
     }
 
-    public static JFreeChart createChart(StaplerRequest req, CategoryDataset dataset) {
+    public static JFreeChart createChart(StaplerRequest2 req, CategoryDataset dataset) {
 
       final JFreeChart chart = ChartFactory.createStackedAreaChart(
           "TAP Tests",                     // chart title
@@ -179,7 +179,7 @@ public class GraphHelper
      *            URL to get to the method from a build test result page
      * @return the chart
      */
-    public static JFreeChart createMethodChart( StaplerRequest req,
+    public static JFreeChart createMethodChart( StaplerRequest2 req,
             final CategoryDataset dataset,
             final Map<NumberOnlyBuildLabel, String> statusMap,
             final String methodUrl )

--- a/src/test/java/org/tap4j/plugin/PublisherKeepsPropertiesTest.java
+++ b/src/test/java/org/tap4j/plugin/PublisherKeepsPropertiesTest.java
@@ -26,27 +26,28 @@ import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestBuilder;
 import org.jvnet.hudson.test.TouchBuilder;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
+@WithJenkins
 public class PublisherKeepsPropertiesTest {
 
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+    private JenkinsRule j;
     private FreeStyleProject project;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp(JenkinsRule j) throws Exception {
+        this.j = j;
         project = j.createFreeStyleProject("tap");
 
         final String tap = "1..2\n" +

--- a/src/test/java/org/tap4j/plugin/PublishersCombinationTest.java
+++ b/src/test/java/org/tap4j/plugin/PublishersCombinationTest.java
@@ -26,8 +26,6 @@ package org.tap4j.plugin;
 import hudson.model.Project;
 import hudson.model.TopLevelItem;
 import org.htmlunit.html.HtmlPage;
-import org.junit.Rule;
-import org.junit.Test;
 import org.junit.jupiter.api.Disabled;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;

--- a/src/test/java/org/tap4j/plugin/TapPublisherPipelineTest.java
+++ b/src/test/java/org/tap4j/plugin/TapPublisherPipelineTest.java
@@ -20,20 +20,18 @@
 package org.tap4j.plugin;
 
 import hudson.model.Result;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 
+@WithJenkins
 public class TapPublisherPipelineTest {
 
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
-
     @Test
-    public void publishTapSymbolWorksWithValidTapFile() throws Exception {
+    public void publishTapSymbolWorksWithValidTapFile(JenkinsRule j) throws Exception {
 
         WorkflowJob job = j.createProject(WorkflowJob.class);
 
@@ -52,4 +50,3 @@ public class TapPublisherPipelineTest {
         j.assertLogContains("TAP Reports Processing: FINISH", run);
     }
 }
-

--- a/src/test/java/org/tap4j/plugin/TapPublisherTest.java
+++ b/src/test/java/org/tap4j/plugin/TapPublisherTest.java
@@ -29,12 +29,12 @@ import hudson.model.FreeStyleProject;
 import hudson.model.Result;
 import hudson.slaves.DumbSlave;
 import hudson.tasks.test.TestResult;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TouchBuilder;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.jvnet.hudson.test.recipes.LocalData;
 import org.tap4j.plugin.model.TapStreamResult;
 import org.tap4j.plugin.model.TapTestResultResult;
@@ -42,24 +42,22 @@ import org.tap4j.plugin.model.TapTestResultResult;
 import java.util.Iterator;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 
-/**
- * Tests for the {@link TapPublisher}.
- */
+@WithJenkins
 public class TapPublisherTest {
 
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+    private JenkinsRule j;
     private FreeStyleProject project;
     private TapPublisher archiver1;
     private TapPublisher archiver2;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp(JenkinsRule j) throws Exception {
+        this.j = j;
         project = j.createFreeStyleProject("tap");
         archiver1 = new TapPublisher(
                 "**/sample.tap",
@@ -115,6 +113,8 @@ public class TapPublisherTest {
         assertTestResultsBasic(build);
 
         try (JenkinsRule.WebClient wc = j.new WebClient()) {
+            wc.getOptions().setFetchPolyfillEnabled(true);
+
             // Check that we can access project page.
             wc.getPage(project);
 
@@ -139,7 +139,7 @@ public class TapPublisherTest {
     @LocalData
     @Test
     // getPage uses deprecation to tell users about a possibility to use relative pages (shrugs)
-    @SuppressWarnings("deprecation")
+    //@SuppressWarnings("deprecation")
     public void merged() throws Exception {
 
         project.getPublishersList().add(archiver2);
@@ -152,6 +152,8 @@ public class TapPublisherTest {
         assertTestResultsMerged(build);
 
         try (JenkinsRule.WebClient wc = j.new WebClient()) {
+            wc.getOptions().setFetchPolyfillEnabled(true);
+
             // Check that we can access project page.
             wc.getPage(project);
 
@@ -238,21 +240,21 @@ public class TapPublisherTest {
 
     private void assertTestResults(FreeStyleBuild build, int total, int failed) {
         TapTestResultAction testResultAction = build.getAction(TapTestResultAction.class);
-        assertNotNull("no TestResultAction", testResultAction);
+        assertNotNull(testResultAction, "no TestResultAction");
 
         TapStreamResult streamResult = testResultAction.getResult();
-        assertNotNull("no TestResult", streamResult);
+        assertNotNull(streamResult, "no TestResult");
 
-        assertEquals(String.format("should have %d failing test", failed), failed, testResultAction.getFailCount());
-        assertEquals(String.format("should have %d failing test", failed), failed, streamResult.getFailCount());
+        assertEquals(failed, testResultAction.getFailCount(), String.format("should have %d failing test", failed));
+        assertEquals(failed, streamResult.getFailCount(), String.format("should have %d failing test", failed));
 
-        assertEquals(String.format("should have %d total tests", total), total, testResultAction.getTotalCount());
-        assertEquals(String.format("should have %d total tests", total), total, streamResult.getTotalCount());
+        assertEquals(total, testResultAction.getTotalCount(), String.format("should have %d total tests", total));
+        assertEquals(total, streamResult.getTotalCount(), String.format("should have %d total tests", total));
 
-        assertEquals(String.format("should have %d skipped test", 1), 1, testResultAction.getSkipCount());
-        assertEquals(String.format("should have %d skipped test", 1), 1, streamResult.getSkipCount());
+        assertEquals(1, testResultAction.getSkipCount(), String.format("should have %d skipped test", 1));
+        assertEquals(1, streamResult.getSkipCount(), String.format("should have %d skipped test", 1));
 
-        assertSame("parent action should be the owning TapTestResultAction", testResultAction, streamResult.getParentAction());
+        assertSame(testResultAction, streamResult.getParentAction(), "parent action should be the owning TapTestResultAction");
     }
 
     /**

--- a/src/test/java/org/tap4j/plugin/flattentapfeature/TestFlattenTapResult.java
+++ b/src/test/java/org/tap4j/plugin/flattentapfeature/TestFlattenTapResult.java
@@ -6,7 +6,7 @@ import hudson.model.FreeStyleBuild;
 import hudson.model.AbstractBuild;
 import hudson.model.FreeStyleProject;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.ByteArrayOutputStream;
 
@@ -16,10 +16,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestBuilder;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.tap4j.model.TestResult;
 import org.tap4j.model.TestSet;
 import org.tap4j.plugin.TapPublisher;
@@ -31,13 +31,12 @@ import org.tap4j.plugin.TapTestResultAction;
  *
  * @author Jakub Podlesak
  */
+@WithJenkins
 public class TestFlattenTapResult {
 
-    @Rule
-    public JenkinsRule jenkins = new JenkinsRule();
 
     @Test
-    public void testMixedLevels() throws IOException, InterruptedException, ExecutionException {
+    public void testMixedLevels(JenkinsRule jenkins) throws IOException, InterruptedException, ExecutionException {
 
         final String tap = "1..2\n" +
                 "  1..3\n" +
@@ -47,11 +46,11 @@ public class TestFlattenTapResult {
                 "ok 1 1\n" +
                 "ok 2 2\n";
 
-        _test(tap, 4, null, false);
+        _test(jenkins, tap, 4, null, false);
     }
 
     @Test
-    public void testStripFirstLevel() throws IOException, InterruptedException, ExecutionException {
+    public void testStripFirstLevel(JenkinsRule jenkins) throws IOException, InterruptedException, ExecutionException {
 
         final String tap = "1..2\n" +
                 "  1..2\n" +
@@ -64,13 +63,13 @@ public class TestFlattenTapResult {
                 "  ok 3 .3\n" +
                 "ok 2 2\n";
 
-        _test(tap, 5, new String[] {
+        _test(jenkins, tap, 5, new String[] {
             "1.1", "1.2",
             "2.1", "2.2", "2.3"}, false);
     }
 
     @Test
-    public void testStripSecondLevel() throws IOException, InterruptedException, ExecutionException {
+    public void testStripSecondLevel(JenkinsRule jenkins) throws IOException, InterruptedException, ExecutionException {
 
         final String tap =
                 "1..1\n" +
@@ -88,14 +87,14 @@ public class TestFlattenTapResult {
                 "  ok 2 .2\n" +
                 "ok 1 1\n";
 
-        _test(tap, 7,
+        _test(jenkins, tap, 7,
                 new String[] {
                     "1.1.1", "1.1.2", "1.1.3", "1.1.4",
                     "1.2.1", "1.2.2", "1.2.3"}, false);
     }
 
     @Test
-    public void testStripSecondLevelIncompleteResult1() throws IOException, InterruptedException, ExecutionException {
+    public void testStripSecondLevelIncompleteResult1(JenkinsRule jenkins) throws IOException, InterruptedException, ExecutionException {
 
         final String tap =
                 "1..1\n" +
@@ -112,14 +111,14 @@ public class TestFlattenTapResult {
                 "  ok 2 .2\n" +
                 "ok 1 1\n";
 
-        _test(tap, 7,
+        _test(jenkins, tap, 7,
                 new String[] {
                     "1.1.1", "1.1.2", "1.1.3", "1.1 failed: 1 subtest(s) missing",
                     "1.2.1", "1.2.2", "1.2.3"}, true);
     }
 
     @Test
-    public void testStripSecondLevelIncompleteResult2() throws IOException, InterruptedException, ExecutionException {
+    public void testStripSecondLevelIncompleteResult2(JenkinsRule jenkins) throws IOException, InterruptedException, ExecutionException {
         final String tap2 =
                 "1..1\n" +
                 "  1..2\n" +
@@ -133,16 +132,16 @@ public class TestFlattenTapResult {
                 "  ok 2 .2\n" +
                 "ok 1 1\n";
 
-        _test(tap2, 6,
+        _test(jenkins, tap2, 6,
                 new String[] {
                     "1.1.1", "1.1.2", "1.1.3", "1.1 failed: 1 subtest(s) missing",
                     "1.2.1", "1.2 failed: 2 subtest(s) missing"}, true);
     }
 
     @Test
-    public void testARealTapOuptut() throws Exception {
+    public void testARealTapOuptut(JenkinsRule jenkins) throws Exception {
         final String tap = _is2String(TestFlattenTapResult.class.getResourceAsStream("/org/tap4j/plugin/tap-master-files/subtest-sample.tap"));
-        _test(tap, 48, null, true);
+        _test(jenkins, tap, 48, null, true);
     }
 
     private String _is2String(InputStream is) throws IOException {
@@ -155,7 +154,7 @@ public class TestFlattenTapResult {
         return result.toString(StandardCharsets.UTF_8);
     }
 
-    private void _test(final String tap, int expectedTotal, String[] expectedDescriptions, boolean printDescriptions) throws IOException, InterruptedException, ExecutionException {
+    private void _test(JenkinsRule jenkins, final String tap, int expectedTotal, String[] expectedDescriptions, boolean printDescriptions) throws IOException, InterruptedException, ExecutionException {
         FreeStyleProject project = jenkins.createProject(FreeStyleProject.class, "flatten-the-file");
 
         project.getBuildersList().add(new TestBuilder() {

--- a/src/test/java/org/tap4j/plugin/issue16647/TestIssue16647.java
+++ b/src/test/java/org/tap4j/plugin/issue16647/TestIssue16647.java
@@ -6,27 +6,27 @@ import hudson.model.FreeStyleBuild;
 import hudson.model.AbstractBuild;
 import hudson.model.FreeStyleProject;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestBuilder;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.tap4j.plugin.TapPublisher;
 import org.tap4j.plugin.TapTestResultAction;
 import org.tap4j.plugin.model.TapStreamResult;
 import org.tap4j.plugin.model.TapTestResultResult;
 
+@WithJenkins
 public class TestIssue16647 {
 
-    @Rule
-    public JenkinsRule jenkins = new JenkinsRule();
 
     @Test
-    public void testDurationMs() throws IOException, InterruptedException, ExecutionException {
+    public void testDurationMs(JenkinsRule jenkins) throws IOException, InterruptedException, ExecutionException {
         FreeStyleProject project = jenkins.createProject(FreeStyleProject.class, "tap-bug-16647");
 
         final String tap = "1..2\n" +

--- a/src/test/java/org/tap4j/plugin/issue16964/TestIssue16964.java
+++ b/src/test/java/org/tap4j/plugin/issue16964/TestIssue16964.java
@@ -7,29 +7,27 @@ import hudson.model.FreeStyleBuild;
 import hudson.model.AbstractBuild;
 import hudson.model.FreeStyleProject;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
 import jakarta.servlet.ServletException;
 
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestBuilder;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.tap4j.plugin.TapPublisher;
 import org.tap4j.plugin.TapResult;
 import org.tap4j.plugin.TapTestResultAction;
 
 
+@WithJenkins
 public class TestIssue16964 {
 
-    @Rule
-    public JenkinsRule jenkins = new JenkinsRule();
-
     @Test
-    public void testFailTestEmptyResultsAndOldReports() throws IOException, InterruptedException, ExecutionException {
+    public void testFailTestEmptyResultsAndOldReports(JenkinsRule jenkins) throws IOException, InterruptedException, ExecutionException {
         FreeStyleProject project = jenkins.createProject(FreeStyleProject.class, "tap-bug-16964");
         
         final String tap = "1..4\n" + 
@@ -72,7 +70,7 @@ public class TestIssue16964 {
                 false);
         project.getPublishersList().add(publisher);
         project.save();
-        FreeStyleBuild build = project.scheduleBuild2(0).get();
+        FreeStyleBuild build = (FreeStyleBuild) project.scheduleBuild2(0).get();
         
         TapTestResultAction action = build.getAction(TapTestResultAction.class);
         TapResult testResult = action.getTapResult();

--- a/src/test/java/org/tap4j/plugin/issue16964/TestIssue16964.java
+++ b/src/test/java/org/tap4j/plugin/issue16964/TestIssue16964.java
@@ -12,7 +12,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import javax.servlet.ServletException;
+import jakarta.servlet.ServletException;
 
 import org.junit.Rule;
 import org.junit.Test;

--- a/src/test/java/org/tap4j/plugin/issue17947/TestIssue17947.java
+++ b/src/test/java/org/tap4j/plugin/issue17947/TestIssue17947.java
@@ -1,31 +1,31 @@
 package org.tap4j.plugin.issue17947;
 
-import junit.framework.TestCase;
-
+import org.junit.jupiter.api.Test;
 import org.tap4j.model.TestSet;
 import org.tap4j.parser.Tap13Parser;
 
-public class TestIssue17947 extends TestCase {
+public class TestIssue17947 {
 
+    @Test
     public void testSubtestsIssue17947() {
         // tap stream provided by issue reporter
-        String tap = "1..3\n" + 
-                "    1..1\n" + 
-                "    ok 1 - subtest 1\n" + 
-                "ok 1 - test 1\n" + 
-                "    1..4\n" + 
-                "    ok 1 - subtest 1\n" + 
-                "    ok 2 - subtest 2\n" + 
-                "    ok 3 - subtest 3\n" + 
-                "    ok 4 - subtest 4\n" + 
-                "ok 2 - test 2\n" + 
-                "    1..15\n" + 
-                "    Bail out!\n" + 
+        String tap = "1..3\n" +
+                "    1..1\n" +
+                "    ok 1 - subtest 1\n" +
+                "ok 1 - test 1\n" +
+                "    1..4\n" +
+                "    ok 1 - subtest 1\n" +
+                "    ok 2 - subtest 2\n" +
+                "    ok 3 - subtest 3\n" +
+                "    ok 4 - subtest 4\n" +
+                "ok 2 - test 2\n" +
+                "    1..15\n" +
+                "    Bail out!\n" +
                 "    not ok 1 - test 3";
-        
+
         Tap13Parser parser = new Tap13Parser(true);
         TestSet ts = parser.parseTapStream(tap);
         System.out.println(ts.getNumberOfTestResults());
     }
-    
+
 }

--- a/src/test/java/org/tap4j/plugin/issue21456/TestIssue21456.java
+++ b/src/test/java/org/tap4j/plugin/issue21456/TestIssue21456.java
@@ -28,10 +28,10 @@ import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.model.FreeStyleProject;
 import hudson.tasks.Shell;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestBuilder;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.tap4j.plugin.TapPublisher;
 import org.tap4j.plugin.TapTestResultAction;
 
@@ -39,18 +39,17 @@ import java.io.IOException;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Tests that Jenkins can be configured to skip using the TAP Plug-in
  * when the build fails.
  */
+@WithJenkins
 public class TestIssue21456 {
 
-    public @Rule JenkinsRule jenkins = new JenkinsRule();
-
     @Test
-    public void testDurationMs() throws IOException, InterruptedException, ExecutionException {
+    public void testDurationMs(JenkinsRule jenkins) throws IOException, InterruptedException, ExecutionException {
         final FreeStyleProject project = jenkins.createFreeStyleProject("tap-bug-21456");
 
         final String tap = String.join("\n",
@@ -100,8 +99,8 @@ public class TestIssue21456 {
                 .getAction(TapTestResultAction.class);
 
         assertNull(
-                "Not supposed to have a TAP action. Should have skipped a failed build!",
-                action);
+                action,
+                "Not supposed to have a TAP action. Should have skipped a failed build!");
     }
 
 }

--- a/src/test/java/org/tap4j/plugin/jenkins_cert_3190/TestXssTapFile.java
+++ b/src/test/java/org/tap4j/plugin/jenkins_cert_3190/TestXssTapFile.java
@@ -27,10 +27,10 @@ import hudson.model.FreeStyleProject;
 import hudson.model.Run;
 import hudson.tasks.Shell;
 import org.htmlunit.CollectingAlertHandler;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.tap4j.plugin.TapPublisher;
 import org.xml.sax.SAXException;
 
@@ -39,7 +39,7 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Prevent a case where TAP files with JavaScript code are
@@ -48,13 +48,11 @@ import static org.junit.Assert.assertEquals;
  * @since 2.4.1
  */
 @Issue("3190")
+@WithJenkins
 public class TestXssTapFile {
 
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
-
     @Test
-    public void testTapFileXss() throws IOException, SAXException, ExecutionException, InterruptedException {
+    public void testTapFileXss(JenkinsRule j) throws IOException, SAXException, ExecutionException, InterruptedException {
         final FreeStyleProject project = j.createFreeStyleProject();
 
         // We can add more scenarios where XSS must be prevented in
@@ -109,7 +107,7 @@ public class TestXssTapFile {
 
             final List<String> alerts = alertHandler.getCollectedAlerts();
 
-            assertEquals("You got a JS alert, look out for XSS!", 0, alerts.size());
+            assertEquals(0, alerts.size(), "You got a JS alert, look out for XSS!");
         }
     }
 }

--- a/src/test/java/org/tap4j/plugin/removeyamlifcorrupted/TestRemoveYamlIfCorrupted.java
+++ b/src/test/java/org/tap4j/plugin/removeyamlifcorrupted/TestRemoveYamlIfCorrupted.java
@@ -6,16 +6,16 @@ import hudson.model.FreeStyleBuild;
 import hudson.model.AbstractBuild;
 import hudson.model.FreeStyleProject;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestBuilder;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.tap4j.plugin.TapPublisher;
 import org.tap4j.plugin.TapResult;
 import org.tap4j.plugin.TapTestResultAction;
@@ -25,13 +25,11 @@ import org.tap4j.plugin.TapTestResultAction;
  *
  * @author Jakub Podlesak
  */
+@WithJenkins
 public class TestRemoveYamlIfCorrupted {
 
-    @Rule
-    public JenkinsRule jenkins = new JenkinsRule();
-
     @Test
-    public void testYamlStripped() throws IOException, InterruptedException, ExecutionException {
+    public void testYamlStripped(JenkinsRule jenkins) throws IOException, InterruptedException, ExecutionException {
 
         final String tap = String.join("\n",
             "1..1",
@@ -78,11 +76,11 @@ public class TestRemoveYamlIfCorrupted {
             "  ..."
         );
 
-        _test("do-not-remove-corrupted-yaml", false, tap, 0);
-        _test("remove-corrupted-yaml", true, tap, 1);
+        _test(jenkins, "do-not-remove-corrupted-yaml", false, tap, 0);
+        _test(jenkins, "remove-corrupted-yaml", true, tap, 1);
     }
 
-    private void _test(String projectName, boolean removeYamlIfCorrupted, final String tap, int expectedTotal) throws IOException, InterruptedException, ExecutionException {
+    private void _test(JenkinsRule jenkins, String projectName, boolean removeYamlIfCorrupted, final String tap, int expectedTotal) throws IOException, InterruptedException, ExecutionException {
         FreeStyleProject project = jenkins.createProject(FreeStyleProject.class, projectName);
 
         project.getBuildersList().add(new TestBuilder() {

--- a/src/test/java/org/tap4j/plugin/stripsingleparent/TestStripSingleParent.java
+++ b/src/test/java/org/tap4j/plugin/stripsingleparent/TestStripSingleParent.java
@@ -6,15 +6,15 @@ import hudson.model.FreeStyleBuild;
 import hudson.model.AbstractBuild;
 import hudson.model.FreeStyleProject;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestBuilder;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.tap4j.plugin.TapPublisher;
 import org.tap4j.plugin.TapResult;
 import org.tap4j.plugin.TapTestResultAction;
@@ -24,13 +24,11 @@ import org.tap4j.plugin.TapTestResultAction;
  *
  * @author Jakub Podlesak
  */
+@WithJenkins
 public class TestStripSingleParent {
 
-    @Rule
-    public JenkinsRule jenkins = new JenkinsRule();
-
     @Test
-    public void testNoEffect() throws IOException, InterruptedException, ExecutionException {
+    public void testNoEffect(JenkinsRule jenkins) throws IOException, InterruptedException, ExecutionException {
 
         final String tap = "1..2\n" +
                 "  1..3\n" +
@@ -40,11 +38,11 @@ public class TestStripSingleParent {
                 "ok 1 - 1\n" +
                 "ok 2 - 1\n";
 
-        _test(tap, 2);
+        _test(jenkins, tap, 2);
     }
 
     @Test
-    public void testStripFirstLevel() throws IOException, InterruptedException, ExecutionException {
+    public void testStripFirstLevel(JenkinsRule jenkins) throws IOException, InterruptedException, ExecutionException {
 
         final String tap = "1..1\n" +
                 "  1..3\n" +
@@ -53,11 +51,11 @@ public class TestStripSingleParent {
                 "  ok 3 1.3\n" +
                 "ok 1 - 1\n";
 
-        _test(tap, 3);
+        _test(jenkins, tap, 3);
     }
 
     @Test
-    public void testStripSecondLevel() throws IOException, InterruptedException, ExecutionException {
+    public void testStripSecondLevel(JenkinsRule jenkins) throws IOException, InterruptedException, ExecutionException {
 
         final String tap =
                 "1..1\n" +
@@ -69,10 +67,10 @@ public class TestStripSingleParent {
                 "  ok 1.1 - 1\n" +
                 "ok 1 - 1\n";
 
-        _test(tap, 3);
+        _test(jenkins, tap, 3);
     }
 
-    private void _test(final String tap, int expectedTotal) throws IOException, InterruptedException, ExecutionException {
+    private void _test(JenkinsRule jenkins, final String tap, int expectedTotal) throws IOException, InterruptedException, ExecutionException {
         FreeStyleProject project = jenkins.createProject(FreeStyleProject.class, "strip-single-parents");
 
         project.getBuildersList().add(new TestBuilder() {

--- a/src/test/java/org/tap4j/plugin/util/GraphHelperTest.java
+++ b/src/test/java/org/tap4j/plugin/util/GraphHelperTest.java
@@ -3,11 +3,17 @@ package org.tap4j.plugin.util;
 
 import hudson.model.TopLevelItem;
 import org.htmlunit.html.HtmlPage;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.jvnet.hudson.test.recipes.LocalData;
+
+import java.net.URL;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -27,11 +33,31 @@ public class GraphHelperTest {
             //      there should be a TAP result trend graph
             rule.assertXPath(page, "//img[@src='tapResults/graph']");
 
-            //      check that tooltip is rendered for the last build
-            rule.assertXPath(page, "//area[@title='1 Failure(s)' and @href='16/tapResults/']");
-
+            rule.assertXPath(page, "//img[@lazymap='tapResults/graphMap']");
             //      check that build without TAP action recorded is excluded from graph
             assertTrue(page.getByXPath("//area[@href='7/tapResults/']").isEmpty());
+
+            //      check that tooltip is rendered for the last build
+            //      The map is now obtained via post, so it can not be seen directly
+            //rule.assertXPath(page, "//area[@title='1 Failure(s)' and @href='16/tapResults/']");
+            //      instead, we will request the map manually
+            //      this is probably bug in HtmlUnit, manual testing is showing the map ok
+            URL map = new URL(page.getUrl()+"/tapResults/graphMap");
+            // see the data-crumb-value="test" in
+            //WebResponse response = page.getWebResponse();
+            //response.getContentAsString();
+            String crumbHeaderName = "Jenkins-Crumb";
+            //if hardcoded test will disappear (see above) extract the value
+            String crumbValue = "test";
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(map.toURI())
+                    .header(crumbHeaderName, crumbValue)
+                    .POST(HttpRequest.BodyPublishers.noBody())
+                    .build();
+            HttpClient client = HttpClient.newBuilder().build();
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            System.out.println(response.body());
+            Assertions.assertTrue(response.body().matches("(?s).*area.*title=.1 Failure\\(s\\).*href=.16/tapResults/..*"));
         }
     }
 }

--- a/src/test/java/org/tap4j/plugin/util/GraphHelperTest.java
+++ b/src/test/java/org/tap4j/plugin/util/GraphHelperTest.java
@@ -3,24 +3,22 @@ package org.tap4j.plugin.util;
 
 import hudson.model.TopLevelItem;
 import org.htmlunit.html.HtmlPage;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.jvnet.hudson.test.recipes.LocalData;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
+@WithJenkins
 public class GraphHelperTest {
-
-    @Rule
-    public JenkinsRule rule = new JenkinsRule();
 
     @Issue("JENKINS-37623")
     @LocalData
     @Test
-    public void renderTooltipsWithFailedBuilds() throws Exception {
+    public void renderTooltipsWithFailedBuilds(JenkinsRule rule) throws Exception {
 
         TopLevelItem project = rule.jenkins.getItem("testPipeline-randomly-no-data");
         try (JenkinsRule.WebClient wc = rule.createWebClient()) {

--- a/src/test/java/org/tap4j/plugin/util/TestUtil.java
+++ b/src/test/java/org/tap4j/plugin/util/TestUtil.java
@@ -23,9 +23,9 @@
  */
 package org.tap4j.plugin.util;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
 /**
@@ -44,10 +44,10 @@ public class TestUtil {
     
     @Test
     public void testNormalizeFolders() {
-        assertEquals("Wrong normalization", "test/subdirectory/another/1.txt", Util.normalizeFolders(UNIX_WS, UNIX_FOLDER_1));
-        assertEquals("Wrong normalization", "/home/anotherfolder/test.txt", Util.normalizeFolders(UNIX_WS, UNIX_FOLDER_2));
-        assertEquals("Wrong normalization", "test/subdirectory/another/1.txt", Util.normalizeFolders(WIN_WS, WIN_FOLDER_1));
-        assertEquals("Wrong normalization", "c:/home/anotherfolder/test.txt", Util.normalizeFolders(WIN_WS, WIN_FOLDER_2));
+        assertEquals("test/subdirectory/another/1.txt", Util.normalizeFolders(UNIX_WS, UNIX_FOLDER_1), "Wrong normalization");
+        assertEquals("/home/anotherfolder/test.txt", Util.normalizeFolders(UNIX_WS, UNIX_FOLDER_2), "Wrong normalization");
+        assertEquals("test/subdirectory/another/1.txt", Util.normalizeFolders(WIN_WS, WIN_FOLDER_1), "Wrong normalization");
+        assertEquals("c:/home/anotherfolder/test.txt", Util.normalizeFolders(WIN_WS, WIN_FOLDER_2), "Wrong normalization");
     }
     
 }


### PR DESCRIPTION
Hello! This PR is updating jenkins plugin parent and baseline jenkins to currently recommended  versions (so ultimately overridwes eg https://github.com/jenkinsci/tap-plugin/pull/46) . That includes (mandatory) bump to junit5 and (optional) fix of  automated jenkins security audit.

I believe the three commits should go as three commits. Unluckily the first (bumped parent/jenkins) can not be properly posted without second (junit5). The third  (`@post`) may be separate PR.  The only logical change should be the change in ` renderTooltipsWithFailedBuilds`, where HtmlUnit is unable to correctly obtain map from `@post` method. Manual testing showed it works fine. 

TLDR:

hi again! Since you stopped to review, and possibly integrate most (all? [1][2][3][4][5]) feature PRs,  and moved to integrate only CVE and necessary fixes, I had tried to co-maintain [6]. That was (correctly!) closed, and you mentioned that I should do something useful, instead of suspicious feature PRs. The issues I had access to, did not seem to be critical enough, so I gave up, and continued living in fork [7].

Unluckily living in private fork is extremely clumsy, and in addition, from time to time I work on projects which have only public jenkins repos available. In that moment when [5] went missing again, and I always had a feeling I'm back in 7th century. The [5] (or something similar is critical to process bigger taps, and I have to deal with taps full of thousands of tests. That also mean that [5] is battle tested, and is not suffering (noticeable) performance regression.

As I'm again bound to project with public repos only, I tired to go with fork out as [8]. It s fate is not yet decided, and I hope on long run you will acept this, [5], maybe more (like  eg [7]), and in ideal word I will be allowed to help you to co-maintan it, as it seems my life is cycrcling about TAP results.. Unbelievable :). I think I would be slightly more vigilant to various mandatory, but not critical  updates, but would be probably more open to 3rd party feature requests.

Anyway the outcome of [8] were:
* https://github.com/jenkins-infra/repository-permissions-updater/issues/5172#issuecomment-5069948838
* and https://github.com/jenkins-infra/repository-permissions-updater/issues/5172#issuecomment-5119905257

Which are both (the first have mandatory consequence of junit5 ) fixed in this PR.

I hope you will find this useful.

[1] https://github.com/jenkinsci/tap-plugin/pull/5 2014
[2] https://github.com/jenkinsci/tap-plugin/pull/11 2016
[3] https://github.com/jenkinsci/tap-plugin/pull/18 2017
[4] https://github.com/jenkinsci/tap-plugin/pull/26 2019
[5] https://github.com/jenkinsci/tap-plugin/pull/38 2024  (+https://github.com/jenkinsci/tap-plugin/pull/29)
[6] https://github.com/jenkins-infra/repository-permissions-updater/pull/3552 
[7] https://github.com/judovana/tap-interactive-plugin
[8] https://github.com/jenkins-infra/repository-permissions-updater/issues/5172
### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
  - refactoring PR. All tests keep passing. Only one needed adjsution

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
